### PR TITLE
Theme propagation

### DIFF
--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "1.2.0"
+    s.version = "1.3.0"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v1.2.0"
+        :tag => "v1.3.0"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.2.0'
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
 	
     s.framework = "UIKit"
 	
-    s.source_files = "MERLin/MERLin/**/*.swift", "MERLin/MERLin/Deeplinking/Extensions/*.{h,m}"
+    s.source_files = "MERLin/MERLin/**/*.swift", "MERLin/MERLin/**/*.{h,m}"
 end

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */; };
 		50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11870213BF89E008928AF /* ModuleManagerTests.swift */; };
 		50B11873213BF89E008928AF /* DeeplinkableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11871213BF89E008928AF /* DeeplinkableTests.swift */; };
+		50F6BCDB214C17C00038DD1B /* ThemeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */; };
+		50F6BCDD214C1C190038DD1B /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDC214C1C190038DD1B /* ThemeTests.swift */; };
+		50F6BCDF214C221B0038DD1B /* MockTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDE214C221B0038DD1B /* MockTheme.swift */; };
 		529C22D3BE9DD3B64B6237AD /* Pods_MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEA1051BC919A6F019688368 /* Pods_MERLin.framework */; };
 		A7139654AE994BD4909AF9CC /* Pods_MERLinTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 293013DF78E94B290AA2C6AA /* Pods_MERLinTests.framework */; };
 /* End PBXBuildFile section */
@@ -107,6 +110,9 @@
 		50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxSwift+EventProtocol.swift"; sourceTree = "<group>"; };
 		50B11870213BF89E008928AF /* ModuleManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleManagerTests.swift; sourceTree = "<group>"; };
 		50B11871213BF89E008928AF /* DeeplinkableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeeplinkableTests.swift; sourceTree = "<group>"; };
+		50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeConfiguration.swift; sourceTree = "<group>"; };
+		50F6BCDC214C1C190038DD1B /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
+		50F6BCDE214C221B0038DD1B /* MockTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTheme.swift; sourceTree = "<group>"; };
 		6679BC817EB0E2029B3D025A /* Pods-MERLin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MERLin/Pods-MERLin.debug.xcconfig"; sourceTree = "<group>"; };
 		DEA1051BC919A6F019688368 /* Pods_MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -190,6 +196,7 @@
 				50B11870213BF89E008928AF /* ModuleManagerTests.swift */,
 				502B9B7221452D6600BBFFC3 /* EventsTests.swift */,
 				502C508821465C8D002B70A4 /* ViewControllerEventsTests.swift */,
+				50F6BCDC214C1C190038DD1B /* ThemeTests.swift */,
 				501D6F152130BB4F00114F5A /* Info.plist */,
 			);
 			path = MERLinTests;
@@ -257,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				501D6F8C2130BD3700114F5A /* ThemeProtocol.swift */,
+				50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */,
 				501D6F8D2130BD3700114F5A /* UIKit+Theming */,
 			);
 			path = Theming;
@@ -301,6 +309,7 @@
 				502C508B21465CD3002B70A4 /* MockDeeplinkableModule.swift */,
 				502C508D21465D6F002B70A4 /* MockViewController.swift */,
 				502C508F21465D91002B70A4 /* MockModule.swift */,
+				50F6BCDE214C221B0038DD1B /* MockTheme.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -497,6 +506,7 @@
 				501D6F702130BD1200114F5A /* BaseModuleManager.swift in Sources */,
 				501D6FA22130BD3800114F5A /* PresentableRoutingStep.swift in Sources */,
 				501D6FA72130BD3800114F5A /* UIColor+Theme.swift in Sources */,
+				50F6BCDB214C17C00038DD1B /* ThemeConfiguration.swift in Sources */,
 				501D6FA12130BD3800114F5A /* ViewControllerBuilding.swift in Sources */,
 				501D6FAF2130BD3800114F5A /* EventsProducer.swift in Sources */,
 				501D6FAA2130BD3800114F5A /* UILabel+Theme.swift in Sources */,
@@ -528,6 +538,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				502C508E21465D6F002B70A4 /* MockViewController.swift in Sources */,
+				50F6BCDD214C1C190038DD1B /* ThemeTests.swift in Sources */,
+				50F6BCDF214C221B0038DD1B /* MockTheme.swift in Sources */,
 				502C508C21465CD3002B70A4 /* MockDeeplinkableModule.swift in Sources */,
 				50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */,
 				502C508921465C8D002B70A4 /* ViewControllerEventsTests.swift in Sources */,

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		500290B9214E85B80025FE20 /* UIWindow+applyAppearence.h in Headers */ = {isa = PBXBuildFile; fileRef = 500290B7214E85B80025FE20 /* UIWindow+applyAppearence.h */; };
+		500290BA214E85B80025FE20 /* UIWindow+applyAppearence.m in Sources */ = {isa = PBXBuildFile; fileRef = 500290B8214E85B80025FE20 /* UIWindow+applyAppearence.m */; };
 		501D6F0F2130BB4F00114F5A /* MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501D6F052130BB4F00114F5A /* MERLin.framework */; };
 		501D6F162130BB4F00114F5A /* MERLin.h in Headers */ = {isa = PBXBuildFile; fileRef = 501D6F082130BB4F00114F5A /* MERLin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		501D6F702130BD1200114F5A /* BaseModuleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F6C2130BD1100114F5A /* BaseModuleManager.swift */; };
@@ -36,6 +38,10 @@
 		501D6FAE2130BD3800114F5A /* EventsListening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F982130BD3700114F5A /* EventsListening.swift */; };
 		501D6FAF2130BD3800114F5A /* EventsProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F992130BD3700114F5A /* EventsProducer.swift */; };
 		501D6FB02130BD3800114F5A /* EventsDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F9A2130BD3700114F5A /* EventsDescriptor.swift */; };
+		5023883A214E30720007BB9D /* ResettableAppearence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50238839214E30720007BB9D /* ResettableAppearence.swift */; };
+		5023883D214E3F320007BB9D /* UIView+ResettableAppearance.h in Headers */ = {isa = PBXBuildFile; fileRef = 5023883B214E3F320007BB9D /* UIView+ResettableAppearance.h */; };
+		5023883E214E3F320007BB9D /* UIView+ResettableAppearance.m in Sources */ = {isa = PBXBuildFile; fileRef = 5023883C214E3F320007BB9D /* UIView+ResettableAppearance.m */; };
+		50238840214E444F0007BB9D /* ResettableAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5023883F214E444F0007BB9D /* ResettableAppearanceTests.swift */; };
 		502B9B7321452D6600BBFFC3 /* EventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502B9B7221452D6600BBFFC3 /* EventsTests.swift */; };
 		502C508921465C8D002B70A4 /* ViewControllerEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502C508821465C8D002B70A4 /* ViewControllerEventsTests.swift */; };
 		502C508C21465CD3002B70A4 /* MockDeeplinkableModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502C508B21465CD3002B70A4 /* MockDeeplinkableModule.swift */; };
@@ -46,7 +52,7 @@
 		50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */; };
 		50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11870213BF89E008928AF /* ModuleManagerTests.swift */; };
 		50B11873213BF89E008928AF /* DeeplinkableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11871213BF89E008928AF /* DeeplinkableTests.swift */; };
-		50F6BCDB214C17C00038DD1B /* ThemeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */; };
+		50F6BCDB214C17C00038DD1B /* UIWindow+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDA214C17C00038DD1B /* UIWindow+Theme.swift */; };
 		50F6BCDD214C1C190038DD1B /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDC214C1C190038DD1B /* ThemeTests.swift */; };
 		50F6BCDF214C221B0038DD1B /* MockTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F6BCDE214C221B0038DD1B /* MockTheme.swift */; };
 		529C22D3BE9DD3B64B6237AD /* Pods_MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEA1051BC919A6F019688368 /* Pods_MERLin.framework */; };
@@ -68,6 +74,8 @@
 		1362662CB514BD99E0C44646 /* Pods-MERLinTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MERLinTests/Pods-MERLinTests.release.xcconfig"; sourceTree = "<group>"; };
 		1C759F7DD275772AEAD8F7F5 /* Pods-MERLin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.release.xcconfig"; path = "Pods/Target Support Files/Pods-MERLin/Pods-MERLin.release.xcconfig"; sourceTree = "<group>"; };
 		293013DF78E94B290AA2C6AA /* Pods_MERLinTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLinTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		500290B7214E85B80025FE20 /* UIWindow+applyAppearence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIWindow+applyAppearence.h"; sourceTree = "<group>"; };
+		500290B8214E85B80025FE20 /* UIWindow+applyAppearence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+applyAppearence.m"; sourceTree = "<group>"; };
 		501D6F052130BB4F00114F5A /* MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		501D6F082130BB4F00114F5A /* MERLin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MERLin.h; sourceTree = "<group>"; };
 		501D6F092130BB4F00114F5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -102,6 +110,10 @@
 		501D6F982130BD3700114F5A /* EventsListening.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsListening.swift; sourceTree = "<group>"; };
 		501D6F992130BD3700114F5A /* EventsProducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsProducer.swift; sourceTree = "<group>"; };
 		501D6F9A2130BD3700114F5A /* EventsDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsDescriptor.swift; sourceTree = "<group>"; };
+		50238839214E30720007BB9D /* ResettableAppearence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResettableAppearence.swift; sourceTree = "<group>"; };
+		5023883B214E3F320007BB9D /* UIView+ResettableAppearance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+ResettableAppearance.h"; sourceTree = "<group>"; };
+		5023883C214E3F320007BB9D /* UIView+ResettableAppearance.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+ResettableAppearance.m"; sourceTree = "<group>"; };
+		5023883F214E444F0007BB9D /* ResettableAppearanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResettableAppearanceTests.swift; sourceTree = "<group>"; };
 		502B9B7221452D6600BBFFC3 /* EventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsTests.swift; sourceTree = "<group>"; };
 		502C508821465C8D002B70A4 /* ViewControllerEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerEventsTests.swift; sourceTree = "<group>"; };
 		502C508B21465CD3002B70A4 /* MockDeeplinkableModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDeeplinkableModule.swift; sourceTree = "<group>"; };
@@ -110,9 +122,10 @@
 		50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxSwift+EventProtocol.swift"; sourceTree = "<group>"; };
 		50B11870213BF89E008928AF /* ModuleManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleManagerTests.swift; sourceTree = "<group>"; };
 		50B11871213BF89E008928AF /* DeeplinkableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeeplinkableTests.swift; sourceTree = "<group>"; };
-		50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeConfiguration.swift; sourceTree = "<group>"; };
+		50F6BCDA214C17C00038DD1B /* UIWindow+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Theme.swift"; sourceTree = "<group>"; };
 		50F6BCDC214C1C190038DD1B /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		50F6BCDE214C221B0038DD1B /* MockTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTheme.swift; sourceTree = "<group>"; };
+		50FDFF8B214E737C00BC5CFD /* MERLin.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = MERLin.podspec; path = ../../MERLin.podspec; sourceTree = "<group>"; };
 		6679BC817EB0E2029B3D025A /* Pods-MERLin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MERLin/Pods-MERLin.debug.xcconfig"; sourceTree = "<group>"; };
 		DEA1051BC919A6F019688368 /* Pods_MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -172,6 +185,7 @@
 		501D6F072130BB4F00114F5A /* MERLin */ = {
 			isa = PBXGroup;
 			children = (
+				50FDFF8B214E737C00BC5CFD /* MERLin.podspec */,
 				501D6F082130BB4F00114F5A /* MERLin.h */,
 				501D6F6E2130BD1200114F5A /* Module.swift */,
 				501D6F6D2130BD1200114F5A /* ModuleBuildContextProtocol.swift */,
@@ -197,6 +211,7 @@
 				502B9B7221452D6600BBFFC3 /* EventsTests.swift */,
 				502C508821465C8D002B70A4 /* ViewControllerEventsTests.swift */,
 				50F6BCDC214C1C190038DD1B /* ThemeTests.swift */,
+				5023883F214E444F0007BB9D /* ResettableAppearanceTests.swift */,
 				501D6F152130BB4F00114F5A /* Info.plist */,
 			);
 			path = MERLinTests;
@@ -264,7 +279,8 @@
 			isa = PBXGroup;
 			children = (
 				501D6F8C2130BD3700114F5A /* ThemeProtocol.swift */,
-				50F6BCDA214C17C00038DD1B /* ThemeConfiguration.swift */,
+				50F6BCDA214C17C00038DD1B /* UIWindow+Theme.swift */,
+				50238839214E30720007BB9D /* ResettableAppearence.swift */,
 				501D6F8D2130BD3700114F5A /* UIKit+Theming */,
 			);
 			path = Theming;
@@ -273,6 +289,10 @@
 		501D6F8D2130BD3700114F5A /* UIKit+Theming */ = {
 			isa = PBXGroup;
 			children = (
+				500290B7214E85B80025FE20 /* UIWindow+applyAppearence.h */,
+				500290B8214E85B80025FE20 /* UIWindow+applyAppearence.m */,
+				5023883B214E3F320007BB9D /* UIView+ResettableAppearance.h */,
+				5023883C214E3F320007BB9D /* UIView+ResettableAppearance.m */,
 				501D6F8E2130BD3700114F5A /* UIButton+Theme.swift */,
 				501D6F8F2130BD3700114F5A /* UIColor+Theme.swift */,
 				501D6F902130BD3700114F5A /* UIColors+Hex.swift */,
@@ -330,8 +350,10 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5023883D214E3F320007BB9D /* UIView+ResettableAppearance.h in Headers */,
 				5074DF32213ECD010021294D /* Module+Deeplink.h in Headers */,
 				501D6F162130BB4F00114F5A /* MERLin.h in Headers */,
+				500290B9214E85B80025FE20 /* UIWindow+applyAppearence.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,7 +528,7 @@
 				501D6F702130BD1200114F5A /* BaseModuleManager.swift in Sources */,
 				501D6FA22130BD3800114F5A /* PresentableRoutingStep.swift in Sources */,
 				501D6FA72130BD3800114F5A /* UIColor+Theme.swift in Sources */,
-				50F6BCDB214C17C00038DD1B /* ThemeConfiguration.swift in Sources */,
+				50F6BCDB214C17C00038DD1B /* UIWindow+Theme.swift in Sources */,
 				501D6FA12130BD3800114F5A /* ViewControllerBuilding.swift in Sources */,
 				501D6FAF2130BD3800114F5A /* EventsProducer.swift in Sources */,
 				501D6FAA2130BD3800114F5A /* UILabel+Theme.swift in Sources */,
@@ -519,13 +541,16 @@
 				501D6F722130BD1200114F5A /* Module.swift in Sources */,
 				501D6F7A2130BD2100114F5A /* ABVariation.swift in Sources */,
 				501D6FAE2130BD3800114F5A /* EventsListening.swift in Sources */,
+				5023883A214E30720007BB9D /* ResettableAppearence.swift in Sources */,
 				501D6FAD2130BD3800114F5A /* RxExtension.swift in Sources */,
 				501D6F9F2130BD3800114F5A /* DisplayableError.swift in Sources */,
 				501D6FA52130BD3800114F5A /* ThemeProtocol.swift in Sources */,
+				5023883E214E3F320007BB9D /* UIView+ResettableAppearance.m in Sources */,
 				50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */,
 				501D6FA92130BD3800114F5A /* UIFont+Theme.swift in Sources */,
 				501D6F712130BD1200114F5A /* ModuleBuildContextProtocol.swift in Sources */,
 				501D6F9B2130BD3800114F5A /* Deeplink.swift in Sources */,
+				500290BA214E85B80025FE20 /* UIWindow+applyAppearence.m in Sources */,
 				501D6FAC2130BD3800114F5A /* NSAttributedString+Theme.swift in Sources */,
 				501D6FA82130BD3800114F5A /* UIColors+Hex.swift in Sources */,
 				501D6FAB2130BD3800114F5A /* UITextField+Theme.swift in Sources */,
@@ -539,6 +564,7 @@
 			files = (
 				502C508E21465D6F002B70A4 /* MockViewController.swift in Sources */,
 				50F6BCDD214C1C190038DD1B /* ThemeTests.swift in Sources */,
+				50238840214E444F0007BB9D /* ResettableAppearanceTests.swift in Sources */,
 				50F6BCDF214C221B0038DD1B /* MockTheme.swift in Sources */,
 				502C508C21465CD3002B70A4 /* MockDeeplinkableModule.swift in Sources */,
 				50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */,

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		500290B9214E85B80025FE20 /* UIWindow+applyAppearence.h in Headers */ = {isa = PBXBuildFile; fileRef = 500290B7214E85B80025FE20 /* UIWindow+applyAppearence.h */; };
 		500290BA214E85B80025FE20 /* UIWindow+applyAppearence.m in Sources */ = {isa = PBXBuildFile; fileRef = 500290B8214E85B80025FE20 /* UIWindow+applyAppearence.m */; };
+		500290BF214E87DE0025FE20 /* SwizzlerUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 500290BD214E87DE0025FE20 /* SwizzlerUtility.h */; };
+		500290C0214E87DE0025FE20 /* SwizzlerUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 500290BE214E87DE0025FE20 /* SwizzlerUtility.m */; };
 		501D6F0F2130BB4F00114F5A /* MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501D6F052130BB4F00114F5A /* MERLin.framework */; };
 		501D6F162130BB4F00114F5A /* MERLin.h in Headers */ = {isa = PBXBuildFile; fileRef = 501D6F082130BB4F00114F5A /* MERLin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		501D6F702130BD1200114F5A /* BaseModuleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F6C2130BD1100114F5A /* BaseModuleManager.swift */; };
@@ -76,6 +78,8 @@
 		293013DF78E94B290AA2C6AA /* Pods_MERLinTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLinTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		500290B7214E85B80025FE20 /* UIWindow+applyAppearence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIWindow+applyAppearence.h"; sourceTree = "<group>"; };
 		500290B8214E85B80025FE20 /* UIWindow+applyAppearence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+applyAppearence.m"; sourceTree = "<group>"; };
+		500290BD214E87DE0025FE20 /* SwizzlerUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwizzlerUtility.h; sourceTree = "<group>"; };
+		500290BE214E87DE0025FE20 /* SwizzlerUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzlerUtility.m; sourceTree = "<group>"; };
 		501D6F052130BB4F00114F5A /* MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		501D6F082130BB4F00114F5A /* MERLin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MERLin.h; sourceTree = "<group>"; };
 		501D6F092130BB4F00114F5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -307,6 +311,8 @@
 		501D6F952130BD3700114F5A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				500290BD214E87DE0025FE20 /* SwizzlerUtility.h */,
+				500290BE214E87DE0025FE20 /* SwizzlerUtility.m */,
 				501D6F962130BD3700114F5A /* RxExtension.swift */,
 				50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */,
 			);
@@ -351,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5023883D214E3F320007BB9D /* UIView+ResettableAppearance.h in Headers */,
+				500290BF214E87DE0025FE20 /* SwizzlerUtility.h in Headers */,
 				5074DF32213ECD010021294D /* Module+Deeplink.h in Headers */,
 				501D6F162130BB4F00114F5A /* MERLin.h in Headers */,
 				500290B9214E85B80025FE20 /* UIWindow+applyAppearence.h in Headers */,
@@ -554,6 +561,7 @@
 				501D6FAC2130BD3800114F5A /* NSAttributedString+Theme.swift in Sources */,
 				501D6FA82130BD3800114F5A /* UIColors+Hex.swift in Sources */,
 				501D6FAB2130BD3800114F5A /* UITextField+Theme.swift in Sources */,
+				500290C0214E87DE0025FE20 /* SwizzlerUtility.m in Sources */,
 				501D6FB02130BD3800114F5A /* EventsDescriptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MERLin/MERLin.xcodeproj/xcshareddata/xcschemes/MERLin.xcscheme
+++ b/MERLin/MERLin.xcodeproj/xcshareddata/xcschemes/MERLin.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+               BuildableName = "MERLin.framework"
+               BlueprintName = "MERLin"
+               ReferencedContainer = "container:MERLin.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+            BuildableName = "MERLin.framework"
+            BlueprintName = "MERLin"
+            ReferencedContainer = "container:MERLin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "501D6F0D2130BB4F00114F5A"
+               BuildableName = "MERLinTests.xctest"
+               BlueprintName = "MERLinTests"
+               ReferencedContainer = "container:MERLin.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+            BuildableName = "MERLin.framework"
+            BlueprintName = "MERLin"
+            ReferencedContainer = "container:MERLin.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+            BuildableName = "MERLin.framework"
+            BlueprintName = "MERLin"
+            ReferencedContainer = "container:MERLin.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+            BuildableName = "MERLin.framework"
+            BlueprintName = "MERLin"
+            ReferencedContainer = "container:MERLin.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MERLin/MERLin/Extensions/SwizzlerUtility.h
+++ b/MERLin/MERLin/Extensions/SwizzlerUtility.h
@@ -1,0 +1,19 @@
+//
+//  SwizzlerUtility.h
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SwizzlerUtility : NSObject
+
++(void) swizzle: (SEL) originalSelector withSelector: (SEL) swizzledSelector onClass: (Class)class;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MERLin/MERLin/Extensions/SwizzlerUtility.m
+++ b/MERLin/MERLin/Extensions/SwizzlerUtility.m
@@ -1,0 +1,33 @@
+//
+//  SwizzlerUtility.m
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import "SwizzlerUtility.h"
+#import <Objc/runtime.h>
+
+@implementation SwizzlerUtility
+
++(void)swizzle:(SEL)originalSelector withSelector:(SEL)swizzledSelector onClass:(Class)class {
+    Method originalMethod = class_getInstanceMethod(class, originalSelector);
+    Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+    
+    //We try to add the implementation of the swizzled method in the original selector.
+    //This operation will succede only if the subclass did not override the original selector.
+    BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+    
+    if (didAddMethod) {
+        //If we succede, we need to replace the swizzled method implementation with the original
+        //method implementation. In short, this case fallsback in a runtime override.
+        class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+    } else {
+        //In case of failure, a method override the original method. Then, a simple exchange of
+        //implementations is enough.
+        method_exchangeImplementations(originalMethod, swizzledMethod);
+    }
+}
+
+@end

--- a/MERLin/MERLin/Module.swift
+++ b/MERLin/MERLin/Module.swift
@@ -15,12 +15,6 @@ public enum ViewControllerEvent: EventProtocol {
     case disappeared
 }
 
-public class ThemeContainer {
-    public static var defaultTheme: ModuleThemeProtocol! {
-        didSet { defaultTheme.applyAppearance() }
-    }
-    public var theme: ModuleThemeProtocol = ThemeContainer.defaultTheme
-}
 
 public protocol AnyModule: class, NSObjectProtocol {
     var viewControllerEvent: Observable<ViewControllerEvent> { get }
@@ -32,6 +26,7 @@ public protocol AnyModule: class, NSObjectProtocol {
 public protocol ModuleProtocol: AnyModule {
     associatedtype Context: ModuleBuildContextProtocol
     var context: Context { get }
+    
     var routingContext: String { get }
     
     init(usingContext buildContext: Context)

--- a/MERLin/MERLin/Theming/ResettableAppearence.swift
+++ b/MERLin/MERLin/Theming/ResettableAppearence.swift
@@ -1,0 +1,58 @@
+//
+//  ResettableAppearence.swift
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+import Foundation
+protocol ResettableUIAppearence: class {
+    func tryCustomize(_ view: UIAppearance)
+}
+
+public class ResettableAppearence<T: UIAppearance>: ResettableUIAppearence {
+    let appearence: (T) -> Void
+    public init(applying appearence: @escaping (T) -> Void = { _ in }) {
+        self.appearence = appearence
+    }
+    
+    func customize(_ view: T) {
+        appearence(view)
+    }
+    
+    func tryCustomize(_ view: UIAppearance) {
+        guard let v = view as? T else { return }
+        customize(v)
+    }
+}
+
+public class AppearanceProxy {
+    static let resettableAppearances: NSMutableDictionary = NSMutableDictionary()
+    static public func resetAppearences() {
+        AppearanceProxy.resettableAppearances.removeAllObjects()
+    }
+}
+
+public extension UIAppearance {
+    static public var resettableAppearance: ResettableAppearence<Self>? {
+        get { return AppearanceProxy.resettableAppearances["\(Self.self)"] as? ResettableAppearence<Self> }
+        set { AppearanceProxy.resettableAppearances.setValue(newValue, forKey: "\(Self.self)") }
+    }
+}
+
+@objc public extension UIView {
+    @objc public func applyAppearence() {
+        var cursor: AnyClass = type(of: self)
+        var propagationTable: [AnyClass] = [cursor]
+        while let superClass = cursor.superclass() {
+            propagationTable.insert(superClass, at: 0)
+            cursor = superClass
+        }
+        
+        for type in propagationTable {
+            guard let proxy = AppearanceProxy.resettableAppearances["\(type)"] as? ResettableUIAppearence else { continue }
+            proxy.tryCustomize(self)
+        }
+    }
+}

--- a/MERLin/MERLin/Theming/ThemeConfiguration.swift
+++ b/MERLin/MERLin/Theming/ThemeConfiguration.swift
@@ -1,0 +1,51 @@
+//
+//  ThemeConfiguration.swift
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 14/09/18.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+import Foundation
+
+private var staticThemeHandle: UInt8 = 0
+private var themeHandle: UInt8 = 0
+public extension UIWindow {
+    public static var defaultTheme: ModuleThemeProtocol {
+        get {
+            return objc_getAssociatedObject(self, &staticThemeHandle) as! ModuleThemeProtocol
+        } set {
+            objc_setAssociatedObject(self, &staticThemeHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            UIApplication.shared.windows.forEach { $0.defaultTheme = newValue }
+        }
+    }
+    public var defaultTheme: ModuleThemeProtocol {
+        get {
+            return objc_getAssociatedObject(self, &themeHandle) as! ModuleThemeProtocol
+        } set {
+            objc_setAssociatedObject(self, &themeHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            newValue.applyAppearance()
+            guard let root = rootViewController else { return }
+            
+            UIWindow.traverseViewControllerStackApplyingTheme(from: root)
+        }
+    }
+    
+    static func traverseViewControllerStackApplyingTheme(from root: UIViewController) {
+        //Standard bredth first traversal. View stack is a tree, therefore
+        //no visited set is needed.
+        var queue = [root]
+        while let controller = queue.first {
+            queue.removeFirst()
+            (controller as? Themed)?.applyTheme()
+            queue += controller.children
+            if let presented = controller.presentedViewController {
+                queue += [presented]
+            }
+        }
+    }
+}
+
+public protocol Themed: UITraitEnvironment {
+    func applyTheme()
+}

--- a/MERLin/MERLin/Theming/ThemeProtocol.swift
+++ b/MERLin/MERLin/Theming/ThemeProtocol.swift
@@ -53,28 +53,28 @@ public enum ThemeFontStyle {
     }
 }
 
-public protocol ModuleThemeProtocol: class {
+public protocol ThemeProtocol: class {
     //MARK: Colors
     func color(forColorPalette colorPalette: ThemeColorPalette) -> UIColor
     
+    //MARK: Fonts
+    func font(forStyle style: ThemeFontStyle) -> UIFont
+    func fontSize(forStyle style: ThemeFontStyle) -> CGFloat
+    
     //MARK: Buttons
-    @discardableResult func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)->Void)?) -> UIButton
-    @discardableResult func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)->Void)?) -> UIButton
-    @discardableResult func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)->Void)?) -> UIButton
+    @discardableResult func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)?) -> UIButton
+    @discardableResult func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)?) -> UIButton
+    @discardableResult func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)?) -> UIButton
     
     //MARK: Labels
     func attributedString(withString string: String, andStyle style: ThemeFontStyle) -> NSAttributedString
     func configure(range: NSRange, of attributedString: NSAttributedString, withStyle style: ThemeFontStyle, andColor color: ThemeColorPalette) -> NSAttributedString
     @discardableResult
-    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ModuleThemeProtocol)->Void)?) -> UILabel
+    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ThemeProtocol)->Void)?) -> UILabel
     
     //MARK: Text Fields
     @discardableResult
-    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol)->Void)?) -> UITextField
-    
-    //MARK: Fonts
-    func font(forStyle style: ThemeFontStyle) -> UIFont
-    func fontSize(forStyle style: ThemeFontStyle) -> CGFloat
+    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ThemeProtocol)->Void)?) -> UITextField
     
     func applyAppearance()
     

--- a/MERLin/MERLin/Theming/ThemeProtocol.swift
+++ b/MERLin/MERLin/Theming/ThemeProtocol.swift
@@ -53,7 +53,7 @@ public enum ThemeFontStyle {
     }
 }
 
-public protocol ModuleThemeProtocol {
+public protocol ModuleThemeProtocol: class {
     //MARK: Colors
     func color(forColorPalette colorPalette: ThemeColorPalette) -> UIColor
     

--- a/MERLin/MERLin/Theming/UIKit+Theming/NSAttributedString+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/NSAttributedString+Theme.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 public extension NSAttributedString {
-    public static func attributedString(withString string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
+    public static func attributedString(withString string: String, andStyle style: ThemeFontStyle, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         return theme.attributedString(withString: string, andStyle: style)
     }
     
-    public static func attributedString(fromHTML string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
+    public static func attributedString(fromHTML string: String, andStyle style: ThemeFontStyle, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         guard let data = string.data(using: .utf8) else { return NSAttributedString() }
         do {
             let attributes: [NSAttributedString.DocumentReadingOptionKey: Any] =
@@ -26,7 +26,7 @@ public extension NSAttributedString {
         }
     }
     
-    public func applyStyle(_ style: ThemeFontStyle, andColor color: ThemeColorPalette, toRange range: NSRange, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
+    public func applyStyle(_ style: ThemeFontStyle, andColor color: ThemeColorPalette, toRange range: NSRange, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         return theme.configure(range: range, of: self, withStyle: style, andColor: color)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/NSAttributedString+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/NSAttributedString+Theme.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 public extension NSAttributedString {
-    public static func attributedString(withString string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme) -> NSAttributedString {
+    public static func attributedString(withString string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         return theme.attributedString(withString: string, andStyle: style)
     }
     
-    public static func attributedString(fromHTML string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme) -> NSAttributedString {
+    public static func attributedString(fromHTML string: String, andStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         guard let data = string.data(using: .utf8) else { return NSAttributedString() }
         do {
             let attributes: [NSAttributedString.DocumentReadingOptionKey: Any] =
@@ -26,7 +26,7 @@ public extension NSAttributedString {
         }
     }
     
-    public func applyStyle(_ style: ThemeFontStyle, andColor color: ThemeColorPalette, toRange range: NSRange, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme) -> NSAttributedString {
+    public func applyStyle(_ style: ThemeFontStyle, andColor color: ThemeColorPalette, toRange range: NSRange, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> NSAttributedString {
         return theme.configure(range: range, of: self, withStyle: style, andColor: color)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIButton+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIButton+Theme.swift
@@ -9,33 +9,33 @@
 import UIKit
 
 public extension UIButton {
-    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyPrimaryButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         theme.configurePrimaryButton(button: self, withTitleStyle: style, customizing: customizing)
     }
     
-    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applySecondaryButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         theme.configureSecondaryButton(button: self, withTitleStyle: style, customizing: customizing)
     }
     
-    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyTextOnlyButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         theme.configureTextOnlyButton(button: self, withTitleStyle: style, customizing: customizing)
     }
 }
 
 public extension Array where Element: UIButton {
-    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyPrimaryButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         forEach {
             theme.configurePrimaryButton(button: $0, withTitleStyle: style, customizing: customizing)
         }
     }
     
-    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applySecondaryButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         forEach {
             theme.configureSecondaryButton(button: $0, withTitleStyle: style, customizing: customizing)
         }
     }
     
-    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyTextOnlyButtonStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)-> Void)? = nil) {
         forEach{
             theme.configureTextOnlyButton(button: $0, withTitleStyle: style, customizing: customizing)
         }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIButton+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIButton+Theme.swift
@@ -9,33 +9,33 @@
 import UIKit
 
 public extension UIButton {
-    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         theme.configurePrimaryButton(button: self, withTitleStyle: style, customizing: customizing)
     }
     
-    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         theme.configureSecondaryButton(button: self, withTitleStyle: style, customizing: customizing)
     }
     
-    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         theme.configureTextOnlyButton(button: self, withTitleStyle: style, customizing: customizing)
     }
 }
 
 public extension Array where Element: UIButton {
-    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyPrimaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         forEach {
             theme.configurePrimaryButton(button: $0, withTitleStyle: style, customizing: customizing)
         }
     }
     
-    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applySecondaryButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         forEach {
             theme.configureSecondaryButton(button: $0, withTitleStyle: style, customizing: customizing)
         }
     }
     
-    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyTextOnlyButtonStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol)-> Void)? = nil) {
         forEach{
             theme.configureTextOnlyButton(button: $0, withTitleStyle: style, customizing: customizing)
         }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIColor+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIColor+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UIColor {
-    public static func color(forPalette palette: ThemeColorPalette, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme) -> UIColor {
+    public static func color(forPalette palette: ThemeColorPalette, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> UIColor {
         return theme.color(forColorPalette: palette)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIColor+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIColor+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UIColor {
-    public static func color(forPalette palette: ThemeColorPalette, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> UIColor {
+    public static func color(forPalette palette: ThemeColorPalette, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme) -> UIColor {
         return theme.color(forColorPalette: palette)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIFont+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIFont+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension UIFont {
-    public static func font(forStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> UIFont {
+    public static func font(forStyle style: ThemeFontStyle, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme) -> UIFont {
         return theme.font(forStyle: style)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIFont+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIFont+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension UIFont {
-    public static func font(forStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme) -> UIFont {
+    public static func font(forStyle style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme) -> UIFont {
         return theme.font(forStyle: style)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UILabel+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UILabel+Theme.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 public extension UILabel {
-    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
+    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
         theme.configure(label: self, withStyle: style, customizing: customizing)
     }
 }
 
 public extension Array where Element: UILabel {
-    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
+    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
         forEach {
             theme.configure(label: $0, withStyle: style, customizing: customizing)
         }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UILabel+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UILabel+Theme.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 public extension UILabel {
-    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
+    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ThemeProtocol)->Void)? = nil) {
         theme.configure(label: self, withStyle: style, customizing: customizing)
     }
 }
 
 public extension Array where Element: UILabel {
-    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ModuleThemeProtocol)->Void)? = nil) {
+    public func applyLabelStyle(_ style: ThemeFontStyle, usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, customizing: ((UILabel, ThemeProtocol)->Void)? = nil) {
         forEach {
             theme.configure(label: $0, withStyle: style, customizing: customizing)
         }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UITextField+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UITextField+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension UITextField {
-    public func applyBoxedStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyBoxedStyle(usingTheme theme: ThemeProtocol = UIWindow.defaultTheme, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ThemeProtocol)-> Void)? = nil) {
         theme.configureBoxedTextField(textfield: self, withTextStyle: style, customizing: customizing)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UITextField+Theme.swift
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UITextField+Theme.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension UITextField {
-    public func applyBoxedStyle(usingTheme theme: ModuleThemeProtocol = ThemeContainer.defaultTheme, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol)-> Void)? = nil) {
+    public func applyBoxedStyle(usingTheme theme: ModuleThemeProtocol = UIWindow.defaultTheme, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol)-> Void)? = nil) {
         theme.configureBoxedTextField(textfield: self, withTextStyle: style, customizing: customizing)
     }
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.h
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.h
@@ -1,0 +1,17 @@
+//
+//  UIView+ResettableAppearance.h
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIView (ResettableAppearance)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.m
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.m
@@ -1,0 +1,48 @@
+//
+//  UIView+ResettableAppearance.m
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import "UIView+ResettableAppearance.h"
+#import <MERLin/MERLin-Swift.h>
+
+@implementation UIView (ResettableAppearance)
+
++(void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(didMoveToWindow);
+        SEL swizzledSelector = @selector(swizzled_didMoveToWindow);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        //We try to add the implementation of the swizzled method in the original selector.
+        //This operation will succede only if the subclass did not override the original selector.
+        BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            //If we succede, we need to replace the swizzled method implementation with the original
+            //method implementation. In short, this case fallsback in a runtime override.
+            class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+        } else {
+            //In case of failure, a method override the original method. Then, a simple exchange of
+            //implementations is enough.
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+-(void) swizzled_didMoveToWindow {
+    //At this point, the method should be swizzled, so calling swizzled_didMoveToWindow is actually
+    //calling the original method.
+    [self swizzled_didMoveToWindow];
+    [self applyAppearence];
+}
+
+@end

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.m
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIView+ResettableAppearance.m
@@ -8,6 +8,7 @@
 
 #import "UIView+ResettableAppearance.h"
 #import <MERLin/MERLin-Swift.h>
+#import "SwizzlerUtility.h"
 
 @implementation UIView (ResettableAppearance)
 
@@ -19,22 +20,7 @@
         SEL originalSelector = @selector(didMoveToWindow);
         SEL swizzledSelector = @selector(swizzled_didMoveToWindow);
         
-        Method originalMethod = class_getInstanceMethod(class, originalSelector);
-        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
-        
-        //We try to add the implementation of the swizzled method in the original selector.
-        //This operation will succede only if the subclass did not override the original selector.
-        BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
-        
-        if (didAddMethod) {
-            //If we succede, we need to replace the swizzled method implementation with the original
-            //method implementation. In short, this case fallsback in a runtime override.
-            class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
-        } else {
-            //In case of failure, a method override the original method. Then, a simple exchange of
-            //implementations is enough.
-            method_exchangeImplementations(originalMethod, swizzledMethod);
-        }
+        [SwizzlerUtility swizzle:originalSelector withSelector:swizzledSelector onClass:class];
     });
 }
 

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.h
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.h
@@ -1,0 +1,17 @@
+//
+//  UIWindow+applyAppearence.h
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIWindow (applyAppearence)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.m
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.m
@@ -8,6 +8,7 @@
 
 #import "UIWindow+applyAppearence.h"
 #import <MERLin/MERLin-Swift.h>
+#import "SwizzlerUtility.h"
 
 @implementation UIWindow (applyAppearence)
 
@@ -19,22 +20,7 @@
         SEL originalSelector = @selector(makeKeyWindow);
         SEL swizzledSelector = @selector(swizzled_makeKeyWindow);
         
-        Method originalMethod = class_getInstanceMethod(class, originalSelector);
-        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
-        
-        //We try to add the implementation of the swizzled method in the original selector.
-        //This operation will succede only if the subclass did not override the original selector.
-        BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
-        
-        if (didAddMethod) {
-            //If we succede, we need to replace the swizzled method implementation with the original
-            //method implementation. In short, this case fallsback in a runtime override.
-            class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
-        } else {
-            //In case of failure, a method override the original method. Then, a simple exchange of
-            //implementations is enough.
-            method_exchangeImplementations(originalMethod, swizzledMethod);
-        }
+        [SwizzlerUtility swizzle:originalSelector withSelector:swizzledSelector onClass:class];
     });
 
 }

--- a/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.m
+++ b/MERLin/MERLin/Theming/UIKit+Theming/UIWindow+applyAppearence.m
@@ -1,0 +1,47 @@
+//
+//  UIWindow+applyAppearence.m
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+#import "UIWindow+applyAppearence.h"
+#import <MERLin/MERLin-Swift.h>
+
+@implementation UIWindow (applyAppearence)
+
++(void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(makeKeyWindow);
+        SEL swizzledSelector = @selector(swizzled_makeKeyWindow);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        //We try to add the implementation of the swizzled method in the original selector.
+        //This operation will succede only if the subclass did not override the original selector.
+        BOOL didAddMethod = class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            //If we succede, we need to replace the swizzled method implementation with the original
+            //method implementation. In short, this case fallsback in a runtime override.
+            class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
+        } else {
+            //In case of failure, a method override the original method. Then, a simple exchange of
+            //implementations is enough.
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+
+}
+
+-(void) swizzled_makeKeyWindow {
+    [self swizzled_makeKeyWindow];
+    [self applyDefaultThemeWithOverrideLocal:NO];
+}
+
+@end

--- a/MERLin/MERLin/Theming/UIWindow+Theme.swift
+++ b/MERLin/MERLin/Theming/UIWindow+Theme.swift
@@ -16,9 +16,9 @@ public extension UIWindow {
             return objc_getAssociatedObject(self, &staticThemeHandle) as! ThemeProtocol
         } set {
             objc_setAssociatedObject(self, &staticThemeHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            UIApplication.shared.windows.forEach {
-                guard $0.theme !== newValue else { return }
-                $0.applyTheme(newValue)
+            UIApplication.shared.windows.forEach { window in
+                guard window.theme === newValue else { return }
+                window.applyTheme(newValue)
             }
         }
     }

--- a/MERLin/MERLinTests/Mocks/MockTheme.swift
+++ b/MERLin/MERLinTests/Mocks/MockTheme.swift
@@ -55,24 +55,24 @@ private extension ThemeFontStyle {
     }
 }
 
-final class MockTheme: ModuleThemeProtocol {
+final class MockTheme: ThemeProtocol {
     func color(forColorPalette colorPalette: ThemeColorPalette) -> UIColor {
         return colorPalette.color
     }
     
-    func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+    func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol) -> Void)?) -> UIButton {
         button.titleLabel?.font = style.font
         customizing?(button, self)
         return button
     }
     
-    func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+    func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol) -> Void)?) -> UIButton {
         button.titleLabel?.font = style.font
         customizing?(button, self)
         return button
     }
     
-    func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+    func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol) -> Void)?) -> UIButton {
         button.titleLabel?.font = style.font
         customizing?(button, self)
         return button
@@ -98,14 +98,13 @@ final class MockTheme: ModuleThemeProtocol {
         return mutableCopy
     }
     
-    
-    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ModuleThemeProtocol) -> Void)?) -> UILabel {
+    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ThemeProtocol) -> Void)?) -> UILabel {
         label.font = style.font
         customizing?(label, self)
         return label
     }
     
-    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol) -> Void)?) -> UITextField {
+    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ThemeProtocol) -> Void)?) -> UITextField {
         textfield.font = font(forStyle: style)
         customizing?(textfield, self)
         return textfield

--- a/MERLin/MERLinTests/Mocks/MockTheme.swift
+++ b/MERLin/MERLinTests/Mocks/MockTheme.swift
@@ -1,0 +1,127 @@
+//
+//  MockTheme.swift
+//  MERLinTests
+//
+//  Created by Giuseppe Lanza on 14/09/18.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+import Foundation
+import MERLin
+
+extension ThemeColorPalette {
+    var color: UIColor {
+        switch self {
+        case .white: return .white
+        case .gray_1, .gray_2, .gray_3, .gray_4: return .gray
+        case .black: return .black
+        case .primary: return .blue
+        case .primaryFocused: return .cyan
+        case .error: return .red
+        case .warning: return .yellow
+        case .success: return .green
+        case .info: return .lightGray
+        case .sales: return .purple
+        case .custom(let color): return color
+        }
+    }
+}
+
+private extension ThemeFontAttribute {
+    func primaryFont(withSize size: CGFloat = UIFont.labelFontSize) -> UIFont {
+        switch self {
+        case .regular: return .systemFont(ofSize: size)
+        case .bold: return .boldSystemFont(ofSize: size)
+        case .sBold: return .systemFont(ofSize: size, weight: .semibold)
+        }
+    }
+}
+
+private extension ThemeFontStyle {
+    var fontSize: CGFloat {
+        switch self {
+        case .small(_): return 11
+        case .caption(_): return 12
+        case .subhead(_): return 13
+        case .body(_): return 15
+        case .headline(_): return 18
+        case .title(_): return 22
+        case .display(_): return 26
+        }
+    }
+    
+    var font: UIFont {
+        return attribute.primaryFont(withSize: fontSize)
+    }
+}
+
+final class MockTheme: ModuleThemeProtocol {
+    func color(forColorPalette colorPalette: ThemeColorPalette) -> UIColor {
+        return colorPalette.color
+    }
+    
+    func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+        button.titleLabel?.font = style.font
+        customizing?(button, self)
+        return button
+    }
+    
+    func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+        button.titleLabel?.font = style.font
+        customizing?(button, self)
+        return button
+    }
+    
+    func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ModuleThemeProtocol) -> Void)?) -> UIButton {
+        button.titleLabel?.font = style.font
+        customizing?(button, self)
+        return button
+    }
+    
+    func attributedString(withString string: String, andStyle style: ThemeFontStyle) -> NSAttributedString {
+        let attributedString = NSAttributedString(string: string,
+                                                  attributes: [
+                                                    .font: style.font,
+                                                    .foregroundColor: color(forColorPalette: .gray_4) ])
+        
+        return attributedString
+    }
+    
+    func configure(range: NSRange, of attributedString: NSAttributedString, withStyle style: ThemeFontStyle, andColor color: ThemeColorPalette) -> NSAttributedString {
+        let mutableCopy = attributedString.mutableCopy() as! NSMutableAttributedString
+        
+        mutableCopy.setAttributes([
+            NSAttributedString.Key.font: style.font,
+            NSAttributedString.Key.foregroundColor: self.color(forColorPalette: color)
+            ], range: range)
+        
+        return mutableCopy
+    }
+    
+    
+    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ModuleThemeProtocol) -> Void)?) -> UILabel {
+        label.font = style.font
+        customizing?(label, self)
+        return label
+    }
+    
+    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ModuleThemeProtocol) -> Void)?) -> UITextField {
+        textfield.font = font(forStyle: style)
+        customizing?(textfield, self)
+        return textfield
+    }
+    
+    func font(forStyle style: ThemeFontStyle) -> UIFont {
+        return style.font
+    }
+    
+    func fontSize(forStyle style: ThemeFontStyle) -> CGFloat {
+        return style.fontSize
+    }
+    
+    func applyAppearance() { }
+    
+    final func cleanThemeCopy() -> MockTheme {
+        return MockTheme()
+    }
+}

--- a/MERLin/MERLinTests/Mocks/MockViewController.swift
+++ b/MERLin/MERLinTests/Mocks/MockViewController.swift
@@ -7,7 +7,13 @@
 //
 
 import UIKit
+import MERLin
 
-class MockViewController: UIViewController { }
+class MockViewController: UIViewController, Themed {
+    var applyTimes: Int = 0
+    func applyTheme() {
+        applyTimes += 1
+    }
+}
 
 

--- a/MERLin/MERLinTests/ResettableAppearanceTests.swift
+++ b/MERLin/MERLinTests/ResettableAppearanceTests.swift
@@ -1,0 +1,96 @@
+//
+//  ResettableAppearanceTests.swift
+//  MERLinTests
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+import XCTest
+@testable import MERLin
+
+class MockView: UIView { }
+class MockView2: MockView { }
+class MockTabBar: UITabBar { }
+class MockTableView: UITableView { }
+class MockNavigationBar: UINavigationBar { }
+
+class ResettableAppearanceTests: XCTestCase {
+    
+    func testThatItCanStoreAppearance() {
+        let viewAppearance = ResettableAppearence<MockView>()
+        MockView.resettableAppearance = viewAppearance
+        XCTAssertTrue(MockView.resettableAppearance === viewAppearance)
+    }
+    
+    func testThatCanHandleCollisions() {
+        let viewAppearance = ResettableAppearence<MockView>()
+        MockView.resettableAppearance = viewAppearance
+        
+        let secondViewAppearance = ResettableAppearence<MockView2>()
+        MockView2.resettableAppearance = secondViewAppearance
+        XCTAssertTrue(MockView.resettableAppearance === viewAppearance)
+        XCTAssertTrue(MockView2.resettableAppearance === secondViewAppearance)
+    }
+    
+    func testThatItCanStoreMutlipleAppearances() {
+        let viewAppearance = ResettableAppearence<MockView>()
+        MockView.resettableAppearance = viewAppearance
+
+        let tabBarAppearance = ResettableAppearence<MockTabBar>()
+        MockTabBar.resettableAppearance = tabBarAppearance
+        XCTAssertTrue(MockView.resettableAppearance === viewAppearance)
+        XCTAssertTrue(MockTabBar.resettableAppearance === tabBarAppearance)
+    }
+    
+    func testThatItCanApplyAppearance() {
+        let expectedColor = UIColor.black
+        let viewAppearance = ResettableAppearence<MockView>(){ view in
+            view.backgroundColor = expectedColor
+        }
+        MockView.resettableAppearance = viewAppearance
+        
+        let view = MockView(frame: .zero)
+        view.applyAppearence()
+        XCTAssertEqual(view.backgroundColor, expectedColor)
+    }
+    
+    func testThatItCanApplyAppearenceWhenMovedToAWindow() {
+        let window = UIWindow()
+        let expectedColor = UIColor.black
+        let viewAppearance = ResettableAppearence<MockView>(){ view in
+            view.backgroundColor = expectedColor
+        }
+        MockView.resettableAppearance = viewAppearance
+        
+        let view = MockView(frame: .zero)
+        window.addSubview(view)
+        XCTAssertEqual(view.backgroundColor, expectedColor)
+    }
+
+    func testThatItCanApplyAppearenceRecursively() {
+        let window = UIWindow()
+        let expectedColor = UIColor.black
+        let viewAppearance = ResettableAppearence<MockView>(){ view in
+            view.backgroundColor = expectedColor
+        }
+        let secondAppearance = ResettableAppearence<MockView2>() { view in
+            view.tintColor = expectedColor
+        }
+        
+        MockView.resettableAppearance = viewAppearance
+        MockView2.resettableAppearance = secondAppearance
+        let view = MockView2(frame: .zero)
+        window.addSubview(view)
+        XCTAssertEqual(view.backgroundColor, expectedColor)
+        XCTAssertEqual(view.tintColor, expectedColor)
+    }
+    
+    func testThatItCanResetAppearance() {
+        let viewAppearance = ResettableAppearence<MockView>()
+        MockView.resettableAppearance = viewAppearance
+
+        AppearanceProxy.resetAppearences()
+        XCTAssertNil(MockView.resettableAppearance)
+    }
+}

--- a/MERLin/MERLinTests/ThemeTests.swift
+++ b/MERLin/MERLinTests/ThemeTests.swift
@@ -44,7 +44,7 @@ class ThemeTests: XCTestCase {
         let window = UIWindow()
         window.rootViewController = root
         
-        window.defaultTheme = MockTheme()
+        window.theme = MockTheme()
         
         for controller in [root]+treeNodes {
             XCTAssertEqual(controller.applyTimes, 1)

--- a/MERLin/MERLinTests/ThemeTests.swift
+++ b/MERLin/MERLinTests/ThemeTests.swift
@@ -1,0 +1,76 @@
+//
+//  ThemeTests.swift
+//  MERLinTests
+//
+//  Created by Giuseppe Lanza on 14/09/18.
+//  Copyright © 2018 Giuseppe Lanza. All rights reserved.
+//
+
+import XCTest
+@testable import MERLin
+
+class ThemeTests: XCTestCase {
+    func testThatItCanApplyThemeToRootViewController() {
+        let root = MockViewController()
+        UIWindow.traverseViewControllerStackApplyingTheme(from: root)
+        XCTAssertEqual(root.applyTimes, 1)
+    }
+    
+    func testThatItCanApplyThemeToChildren() {
+        let root = MockViewController()
+        let children = prepareChildren(for: root)
+        
+        UIWindow.traverseViewControllerStackApplyingTheme(from: root)
+
+        for controller in [root]+children {
+            XCTAssertEqual(controller.applyTimes, 1)
+        }
+    }
+    
+    func testThatItCanApplyThemeToArbitraryDepthOfChildren() {
+        let root = MockViewController()
+        let treeNodes = prepareHeavilyUnbalancedTree(withDepth: 10, havingRoot: root)
+        
+        UIWindow.traverseViewControllerStackApplyingTheme(from: root)
+
+        for controller in [root]+treeNodes {
+            XCTAssertEqual(controller.applyTimes, 1)
+        }
+    }
+    
+    func testThatChangingThemeAppliesChanges() {
+        let root = MockViewController()
+        let treeNodes = prepareHeavilyUnbalancedTree(withDepth: 10, havingRoot: root)
+        let window = UIWindow()
+        window.rootViewController = root
+        
+        window.defaultTheme = MockTheme()
+        
+        for controller in [root]+treeNodes {
+            XCTAssertEqual(controller.applyTimes, 1)
+        }
+    }
+    
+    func prepareHeavilyUnbalancedTree(withDepth depth: Int, havingRoot root: MockViewController) -> [MockViewController] {
+        var treeNodes = prepareChildren(for: root)
+        
+        var currentRoot = root
+        
+        for _ in 0..<10 {
+            for controller in currentRoot.children {
+                treeNodes += prepareChildren(for: controller)
+            }
+            currentRoot = treeNodes.last!
+        }
+
+        return treeNodes
+    }
+    
+    func prepareChildren(for root: UIViewController) -> [MockViewController] {
+        let children = Array(repeating: MockViewController(), count: 10)
+        children.forEach(root.addChild)
+        return children
+    }
+    
+    
+}

--- a/MERLinSample/MERLinSample.xcodeproj/project.pbxproj
+++ b/MERLinSample/MERLinSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		500290C2214E9FB40025FE20 /* ChristmasTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500290C1214E9FB40025FE20 /* ChristmasTheme.swift */; };
 		50B11881213C19F8008928AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11880213C19F8008928AF /* AppDelegate.swift */; };
 		50B11888213C19FA008928AF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50B11887213C19FA008928AF /* Assets.xcassets */; };
 		50B1188B213C19FA008928AF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 50B11889213C19FA008928AF /* LaunchScreen.storyboard */; };
@@ -89,6 +90,7 @@
 		19FBE482839A1D3901C462C1 /* Pods-MERLinTargets-MERLinSample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTargets-MERLinSample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MERLinTargets-MERLinSample/Pods-MERLinTargets-MERLinSample.debug.xcconfig"; sourceTree = "<group>"; };
 		2A194FC03A0E25A97C5F4F78 /* Pods-MERLinTargets-RestaurantDetailModule.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTargets-RestaurantDetailModule.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MERLinTargets-RestaurantDetailModule/Pods-MERLinTargets-RestaurantDetailModule.debug.xcconfig"; sourceTree = "<group>"; };
 		3B032D153F7BCB379008B00B /* Pods-MERLinTargets-RestaurantsListModule.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTargets-RestaurantsListModule.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MERLinTargets-RestaurantsListModule/Pods-MERLinTargets-RestaurantsListModule.debug.xcconfig"; sourceTree = "<group>"; };
+		500290C1214E9FB40025FE20 /* ChristmasTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChristmasTheme.swift; sourceTree = "<group>"; };
 		50B1187D213C19F8008928AF /* MERLinSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MERLinSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B11880213C19F8008928AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		50B11887213C19FA008928AF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 			children = (
 				50B118CB213C34E9008928AF /* UIButton+Setters.swift */,
 				50B118C9213C34DF008928AF /* Theme.swift */,
+				500290C1214E9FB40025FE20 /* ChristmasTheme.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -618,6 +621,7 @@
 				50B118CA213C34DF008928AF /* Theme.swift in Sources */,
 				50B11881213C19F8008928AF /* AppDelegate.swift in Sources */,
 				50B118D3213C3633008928AF /* AppDelegateEventsListener.swift in Sources */,
+				500290C2214E9FB40025FE20 /* ChristmasTheme.swift in Sources */,
 				50B118CC213C34E9008928AF /* UIButton+Setters.swift in Sources */,
 				50B11902213C4679008928AF /* RestaurantDetailStep.swift in Sources */,
 				50B11895213C1BC9008928AF /* AppDelegateEvents.swift in Sources */,

--- a/MERLinSample/MERLinSample/AppDelegate.swift
+++ b/MERLinSample/MERLinSample/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, EventsProducer {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         router = SimpleRouter(withFactory: moduleManager)
         moduleManager.addEventsListeners(eventsListeners)
-        ThemeContainer.defaultTheme = Theme()
+        UIWindow.defaultTheme = Theme()
         
         eventsListeners.forEach { $0.registerToEvents(for: self) }
         

--- a/MERLinSample/MERLinSample/Router/SimpleRouter.swift
+++ b/MERLinSample/MERLinSample/Router/SimpleRouter.swift
@@ -9,20 +9,54 @@
 import MERLin
 import RxSwift
 
+enum Themes {
+    case defaultTheme, christmasTheme
+    
+    var theme: ThemeProtocol {
+        switch self {
+        case .defaultTheme: return Theme()
+        case .christmasTheme: return ChristmasTheme()
+        }
+    }
+    
+    func next() -> Themes {
+        guard case .defaultTheme = self else { return .defaultTheme }
+        return .christmasTheme
+    }
+}
+
 class SimpleRouter: Router {
     var viewControllersFactory: ViewControllersFactory?
-    
+    let disposeBag = DisposeBag()
     required init(withFactory factory: ViewControllersFactory) {
         viewControllersFactory = factory
+    }
+    
+    var currentTheme: Themes = .defaultTheme {
+        didSet {
+            UIWindow.defaultTheme = currentTheme.theme
+        }
+    }
+    
+    var switchThemeButton: UIBarButtonItem {
+        let button = UIBarButtonItem(title: "Switch Theme", style: .plain, target: nil, action: nil)
+        button.rx.tap.subscribe(onNext: { [weak self] in
+            guard let _self = self else { return }
+            _self.currentTheme = _self.currentTheme.next()
+        }).disposed(by: disposeBag)
+        return button
     }
     
     var topViewController: UIViewController { return rootNavigationController }
     private lazy var rootNavigationController: UINavigationController =  {
         let presentableStep = PresentableRoutingStep(withStep: .restaurantsList(), presentationMode: .embed)
-        return UINavigationController(rootViewController: viewControllersFactory!.viewController(for: presentableStep))
+        let navController = UINavigationController(rootViewController: viewControllersFactory!.viewController(for: presentableStep))
+        navController.rx.willShow
+            .subscribe(onNext: { [weak self] (controller, animated) in
+                controller.navigationItem.rightBarButtonItem = self?.switchThemeButton
+        }).disposed(by: disposeBag)
+        return navController
     }()
-    
-    let disposeBag: DisposeBag = DisposeBag()
     
     func rootViewController(forLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> UIViewController? {
         return rootNavigationController

--- a/MERLinSample/MERLinSample/Theme/ChristmasTheme.swift
+++ b/MERLinSample/MERLinSample/Theme/ChristmasTheme.swift
@@ -1,0 +1,266 @@
+//
+//  ChristmasTheme.swift
+//  MERLinSample
+//
+//  Created by Giuseppe Lanza on 16/09/2018.
+//  Copyright © 2018 HBCDigital. All rights reserved.
+//
+
+
+import UIKit
+import MERLin
+
+fileprivate extension ThemeFontAttribute {
+    func primaryFont(withSize size: CGFloat = UIFont.labelFontSize) -> UIFont {
+        switch self {
+        case .regular: return .systemFont(ofSize: size)
+        case .bold: return .boldSystemFont(ofSize: size)
+        case .sBold: return .systemFont(ofSize: size, weight: .semibold)
+        }
+    }
+}
+
+fileprivate extension ThemeFontStyle {
+    var fontSize: CGFloat {
+        switch self {
+        case .small(_): return 11
+        case .caption(_): return 12
+        case .subhead(_): return 13
+        case .body(_): return 15
+        case .headline(_): return 18
+        case .title(_): return 22
+        case .display(_): return 26
+        }
+    }
+    
+    var font: UIFont {
+        return attribute.primaryFont(withSize: fontSize)
+    }
+}
+
+fileprivate extension ThemeColorPalette {
+    var color: UIColor {
+        switch self {
+        case .white: return .white
+        case .gray_1: return .color(fromHex: "#f7f7f7")
+        case .gray_2: return .color(fromHex: "#dedede")
+        case .gray_3: return .color(fromHex: "#9e9e9e")
+        case .gray_4: return .color(fromHex: "#3d3d3d")
+        case .black: return .color(fromHex: "#1a1a1a")
+        case .primary: return .color(fromHex: "#d42426")
+        case .primaryFocused: return .color(fromHex: "#e04b4c")
+        case .error: return .color(fromHex: "#ff0000")
+        case .warning: return .color(fromHex: "#d58d24")
+        case .success: return .color(fromHex: "#22b21e")
+        case .info: return .color(fromHex: "#1e5db2")
+        case .sales: return .color(fromHex: "#22b21e")
+        case .custom(let color): return color
+        }
+    }
+}
+
+final class ChristmasTheme: ThemeProtocol {
+    
+    func color(forColorPalette colorPalette: ThemeColorPalette) -> UIColor {
+        return colorPalette.color
+    }
+    
+    func font(forStyle style: ThemeFontStyle) -> UIFont {
+        return style.font
+    }
+    
+    func fontSize(forStyle style: ThemeFontStyle) -> CGFloat {
+        return style.fontSize
+    }
+    
+    func applyAppearance() {
+        //UINavigationBar
+        print("APPLYING APPEARANCE")
+        UINavigationBar.resettableAppearance = ResettableAppearence() { [weak self] navBar in
+            guard let _self = self else { return }
+            navBar.isTranslucent = false
+            navBar.barTintColor = _self.color(forColorPalette: .primary)
+            navBar.tintColor = _self.color(forColorPalette: .white)
+            navBar.titleTextAttributes = [
+                .font: _self.font(forStyle: .headline(attribute: .bold)),
+                .foregroundColor: _self.color(forColorPalette: .success)
+            ]
+        }
+        
+        //UIBarButtonItem
+        UIBarButtonItem.resettableAppearance = ResettableAppearence() { [weak self] barButtonItem in
+            guard let _self = self else { return }
+            barButtonItem.setTitleTextAttributes([
+                .font: _self.font(forStyle: .body(attribute: .regular)),
+                .foregroundColor: _self.color(forColorPalette: .primary)
+                ], for: .normal)
+            
+            barButtonItem.setTitleTextAttributes([
+                .font: _self.font(forStyle: .body(attribute: .regular)),
+                .foregroundColor: _self.color(forColorPalette: .gray_4)
+                ], for: .highlighted)
+            
+            barButtonItem.setTitleTextAttributes([
+                .font: _self.font(forStyle: .body(attribute: .regular)),
+                .foregroundColor: _self.color(forColorPalette: .gray_3)
+                ], for: .disabled)
+        }
+        
+        
+        //UITabBar
+        UITabBar.resettableAppearance = ResettableAppearence() { [weak self] tabBar in
+            tabBar.isTranslucent = false
+            tabBar.barTintColor = .white
+            tabBar.tintColor = self?.color(forColorPalette: .primary)
+        }
+        
+        //UITabBarItem
+        UITabBarItem.resettableAppearance = ResettableAppearence() { [weak self] tabBarItem in
+            guard let _self = self else { return }
+            tabBarItem.badgeColor = _self.color(forColorPalette: .primary)
+            tabBarItem.setTitleTextAttributes([
+                .font: _self.font(forStyle: .small(attribute: .regular)),
+                .foregroundColor: _self.color(forColorPalette: .primary)
+                ], for: .selected)
+        }
+        
+        UITextField.resettableAppearance = ResettableAppearence() { [weak self] textField in
+            guard let _self = self else { return }
+            var isContainedInSearchBar = false
+            var cursor: UIView = textField
+            while let superView = cursor.superview {
+                guard let _ = superView as? UISearchBar else {
+                    cursor = superView
+                    continue
+                }
+                isContainedInSearchBar = true
+                break
+            }
+            guard isContainedInSearchBar else { return }
+            
+            textField.defaultTextAttributes = convertToNSAttributedStringKeyDictionary([
+                NSAttributedString.Key.font.rawValue: _self.font(forStyle: .body(attribute: .regular)),
+                NSAttributedString.Key.foregroundColor.rawValue: _self.color(forColorPalette: .gray_4)
+                ])
+        }
+    }
+    
+    func cleanThemeCopy() -> ChristmasTheme {
+        return ChristmasTheme()
+    }
+}
+
+//MARK: - Labels
+
+extension ChristmasTheme {
+    func attributedString(withString string: String, andStyle style: ThemeFontStyle) -> NSAttributedString {
+        let attributedString = NSAttributedString(string: string,
+                                                  attributes: [
+                                                    .font: style.font,
+                                                    .foregroundColor: color(forColorPalette: .gray_4) ])
+        
+        return attributedString
+    }
+    
+    func configure(range: NSRange, of attributedString: NSAttributedString, withStyle style: ThemeFontStyle, andColor color: ThemeColorPalette) -> NSAttributedString {
+        let mutableCopy = attributedString.mutableCopy() as! NSMutableAttributedString
+        
+        mutableCopy.setAttributes([
+            NSAttributedString.Key.font: style.font,
+            NSAttributedString.Key.foregroundColor: self.color(forColorPalette: color)
+            ], range: range)
+        
+        return mutableCopy
+    }
+    
+    @discardableResult
+    func configure(label: UILabel, withStyle style: ThemeFontStyle, customizing: ((UILabel, ThemeProtocol)->Void)?) -> UILabel {
+        label.font = style.font
+        label.textColor = color(forColorPalette: .gray_4)
+        
+        customizing?(label, self)
+        
+        return label
+    }
+}
+
+//MARK: - Buttons
+
+extension ChristmasTheme {
+    @discardableResult
+    func configurePrimaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)? = nil) -> UIButton {
+        button.setupTitle(font: style.font)
+            .setupLayer(cornerRadius: 2, borderWidth: 0, borderColor: nil)
+            .setBackgroundColor(color: color(forColorPalette: .primary), for: .normal)
+            .setBackgroundColor(color: color(forColorPalette: .gray_2), for: .disabled)
+            .setBackgroundColor(color: color(forColorPalette: .primaryFocused), for: [.highlighted, .focused])
+            .setTitleTextColor(color: color(forColorPalette: .white), for: .normal)
+            .setTitleTextColor(color: color(forColorPalette: .gray_3), for: .disabled)
+            .tintColor = .white
+        
+        button.showsTouchWhenHighlighted = false
+        
+        customizing?(button, self)
+        
+        return button
+    }
+    
+    @discardableResult
+    func configureSecondaryButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)? = nil) -> UIButton {
+        button.setupTitle(font: style.font)
+            .setupLayer(cornerRadius: 4, borderWidth: 1, borderColor: color(forColorPalette: .primary).cgColor)
+            .resetBackgrounds()
+            .setTitleTextColor(color: color(forColorPalette: .primary), for: .normal)
+            .tintColor = color(forColorPalette: .primary)
+        
+        button.showsTouchWhenHighlighted = false
+        
+        customizing?(button, self)
+        
+        return button
+    }
+    
+    @discardableResult
+    func configureTextOnlyButton(button: UIButton, withTitleStyle style: ThemeFontStyle, customizing: ((UIButton, ThemeProtocol)->Void)? = nil) -> UIButton {
+        button.setupTitle(font: style.font)
+            .setupLayer(cornerRadius: 0, borderWidth: 0, borderColor: nil)
+            .resetBackgrounds()
+            .setTitleTextColor(color: color(forColorPalette: .primary), for: .normal)
+            .setTitleTextColor(color: color(forColorPalette: .gray_3), for: .disabled)
+            .setTitleTextColor(color: color(forColorPalette: .gray_1), for: [.highlighted, .focused])
+            .tintColor = color(forColorPalette: .primary)
+        
+        button.showsTouchWhenHighlighted = false
+        
+        customizing?(button, self)
+        
+        return button
+    }
+}
+
+//TextField
+extension ChristmasTheme {
+    @discardableResult
+    func configureBoxedTextField(textfield: UITextField, withTextStyle style: ThemeFontStyle, customizing: ((UITextField, ThemeProtocol)->Void)? = nil) -> UITextField {
+        
+        textfield.backgroundColor = color(forColorPalette: .gray_1)
+        textfield.font = font(forStyle: style)
+        textfield.textColor = color(forColorPalette: .black)
+        textfield.autocorrectionType = .no
+        textfield.autocapitalizationType = .none
+        
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: textfield.frame.height))
+        paddingView.backgroundColor = .clear
+        textfield.leftView = paddingView
+        textfield.leftViewMode = .always
+        
+        customizing?(textfield, self)
+        return textfield
+    }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToNSAttributedStringKeyDictionary(_ input: [String: Any]) -> [NSAttributedString.Key: Any] {
+    return Dictionary(uniqueKeysWithValues: input.map { key, value in (NSAttributedString.Key(rawValue: key), value)})
+}
+

--- a/MERLinSample/Podfile.lock
+++ b/MERLinSample/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - LNZWeakCollection (1.2.0)
-  - MERLin (1.2.0):
+  - MERLin (1.3.0):
     - LNZWeakCollection (~> 1.2.0)
     - RxCocoa (~> 4.2.0)
   - RxCocoa (4.2.0):
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   LNZWeakCollection: 1e3ef61bc5ea104e8c9f36ed5a4a03667b413088
-  MERLin: c3f3f489212c611da8ba783617584d7b413d8235
+  MERLin: 0363665107d82d12635c5f4fa01ca46413b0dac5
   RxCocoa: 0b54909c902e1e581212a03e690bbd94032d8baa
   RxSwift: 99e10317ddfcc7fbe01356aafd118fde4a0be104
 

--- a/MERLinSample/RestaurantDetailModule/View/MenuItemCell.swift
+++ b/MERLinSample/RestaurantDetailModule/View/MenuItemCell.swift
@@ -14,16 +14,11 @@ class MenuItemCell: UITableViewCell {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var priceLabel: UILabel!
     
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        
+    func applyAppearance() {
         title.applyLabelStyle(.body(attribute: .regular))
         descriptionLabel.applyLabelStyle(.caption(attribute: .regular))
         priceLabel.applyLabelStyle(.body(attribute: .bold))
         priceLabel.textColor = .color(forPalette: .primary)
     }
-    
-    override func prepareForReuse() {
-        super.prepareForReuse()
-    }
+
 }

--- a/MERLinSample/RestaurantDetailModule/View/RestaurantDetailViewController.swift
+++ b/MERLinSample/RestaurantDetailModule/View/RestaurantDetailViewController.swift
@@ -20,7 +20,7 @@ enum DetailSectionRows: Int {
     }
 }
 
-class RestaurantDetailViewController: UIViewController, DisplayingError, UITableViewDelegate, UITableViewDataSource {
+class RestaurantDetailViewController: UIViewController, DisplayingError, UITableViewDelegate, UITableViewDataSource, Themed {
     func displayError(_ error: DisplayableError) {
         let alert = UIAlertController(title: error.title, message: error.errorMessage, preferredStyle: .alert)
         let action = UIAlertAction(title: "Ok", style: .default, handler: nil)
@@ -43,7 +43,7 @@ class RestaurantDetailViewController: UIViewController, DisplayingError, UITable
     let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
-        bookButton.applyPrimaryButtonStyle(withTitleStyle: .body(attribute: .bold))
+        applyTheme()
         bookButton.setTitle("Book a Table", for: .normal)
         
         let viewWillAppear = rx.sentMessage(#selector(viewWillAppear(_:)))
@@ -67,6 +67,11 @@ class RestaurantDetailViewController: UIViewController, DisplayingError, UITable
         output.error
             .drive(onNext: displayError)
             .disposed(by: disposeBag)
+    }
+    
+    func applyTheme() {
+        bookButton.applyPrimaryButtonStyle(withTitleStyle: .body(attribute: .bold))
+        tableview.reloadData()
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -99,6 +104,7 @@ class RestaurantDetailViewController: UIViewController, DisplayingError, UITable
             let item = menu.items[indexPath.row]
             
             let cell = tableView.dequeueReusableCell(withIdentifier: "menuItemCell", for: indexPath) as! MenuItemCell
+            cell.applyAppearance()
             
             cell.title.text = item.title
             cell.descriptionLabel.text = item.shortDescription

--- a/MERLinSample/RestaurantsListModule/View/RestaurantsListViewController.swift
+++ b/MERLinSample/RestaurantsListModule/View/RestaurantsListViewController.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class RestaurantsListViewController: UITableViewController, DisplayingError {
+class RestaurantsListViewController: UITableViewController, DisplayingError, Themed {
     func displayError(_ error: DisplayableError) {
         let alert = UIAlertController(title: error.title, message: error.errorMessage, preferredStyle: .alert)
         let action = UIAlertAction(title: "Ok", style: .default, handler: nil)
@@ -61,6 +61,10 @@ class RestaurantsListViewController: UITableViewController, DisplayingError {
             self.items = self.items+restaurants
             self.tableView.reloadData()
         }).disposed(by: disposeBag)
+    }
+    
+    func applyTheme() {
+        tableView.reloadData()
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
This is a first look the the new theme system.

`ResettableAppearence` is introduced in this PR. This class should be use instead of `UIAppearance` in order to have reset behaviour. It solves the problem that UIAppearance changes cannot be reset for new components. Unfortunately at this point the problem of existing components is still existing, hence, if the new theme does not override the appearance properties set in the previous theme, these will stay until the new component is recreated.

The ThemeContainer was removed and the defaultTheme is now moved in a UIWindow extension. 

Apparently Theme is now completely detached from the concept of Module, and in the future it might become a pod itself as it's independent from MERLin.

The sample project has a working example of theme switching.