### PR TITLE
Fix a bug producing the remainder of a deeplink when there are multiple schemas

### DIFF
--- a/MERLin/MERLin/Deeplinking/Deeplink.swift
+++ b/MERLin/MERLin/Deeplinking/Deeplink.swift
@@ -62,7 +62,11 @@ public extension Deeplinkable {
      nil if there are no unmatched parameters in the deeplink.
      */
     public static func remainderDeeplink(fromDeeplink deeplink: String) -> String? {
-        guard let schema = deeplinkSchemaNames.first,
+        let optionalSchema = deeplinkSchemaNames.first {
+            return deeplink.hasPrefix($0)
+        }
+        
+        guard let schema = optionalSchema,
             let match = deeplinkRegexes()?.compactMap({ $0.firstMatch(in: deeplink, range: NSRange(location: 0, length: deeplink.count)) }).first,
             let range = Range(match.range(at: 0), in: deeplink) else { return nil }
         

--- a/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
@@ -12,7 +12,7 @@ import MERLin
 class MockViewController: UIViewController {}
 
 class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
-    static var deeplinkSchemaNames: [String] = ["test"]
+    static var deeplinkSchemaNames: [String] = ["test", "anotherTest"]
     
     var context: ModuleContext
     
@@ -39,8 +39,11 @@ class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
     }
     
     static func deeplinkRegexes() -> [NSRegularExpression]? {
-        let regEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
-        let productRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/product\\/?([0-9]+)", options: .caseInsensitive)
-        return [regEx, productRegEx]
+        let testRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
+        let testProductRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/product\\/?([0-9]+)", options: .caseInsensitive)
+        let anotherTestRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
+        let anotherTestProductRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/product\\/?([0-9]+)", options: .caseInsensitive)
+        
+        return [testRegEx, testProductRegEx, anotherTestRegEx, anotherTestProductRegEx]
     }
 }

--- a/MERLin/MERLinTests/Tests/Modules/DeeplinkableTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/DeeplinkableTests.swift
@@ -35,6 +35,16 @@ class DeeplinkableTests: XCTestCase {
         XCTAssertEqual(remainder, expectedRemainder)
     }
     
+    func testDeeplinkRemainderWithSecondSchema() {
+        let deeplink = "anotherTest://mock/product/1234"
+        let expectedRemainder = "anotherTest://product/1234"
+        
+        let remainder = MockDeeplinkable.remainderDeeplink(fromDeeplink: deeplink)
+        XCTAssertNotNil(remainder)
+        
+        XCTAssertEqual(remainder, expectedRemainder)
+    }
+    
     func testDeeplinkRemainderWithMatchingGroup() {
         let deeplink = "test://mock/2341234/product/1234"
         let expectedRemainder = "test://product/1234"


### PR DESCRIPTION
The function to get the remainder of a deeplink was always taking the first schema name rather than using the same schema as the original deeplink. This is a problem if there are different regular expressions for each schema name as the remainder link will not be properly parsed.