### PR TITLE
Introduced priority for deeplinks

### DIFF
--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "1.5.1"
+    s.version = "1.5.2"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v1.5.1"
+        :tag => "v1.5.2"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.2.0'

--- a/MERLin/MERLin/BaseModuleManager.swift
+++ b/MERLin/MERLin/BaseModuleManager.swift
@@ -65,11 +65,15 @@ open class BaseModuleManager {
 extension BaseModuleManager: DeeplinkManaging {
     // MARK: - Deeplinks
     
-    private func deeplinkable(fromDeeplink deeplink: String) -> Deeplinkable.Type? {
-        guard let type = DeeplinkMatcher.typedAvailableDeeplinkHandlers.compactMap({ (pair) -> Deeplinkable.Type? in
+    func deeplinkable(fromDeeplink deeplink: String) -> Deeplinkable.Type? {
+        let responders = DeeplinkMatcher.typedAvailableDeeplinkHandlers.compactMap({ (pair) -> Deeplinkable.Type? in
             let (key, value) = pair
             guard key.numberOfMatches(in: deeplink, range: NSRange(location: 0, length: deeplink.count)) > 0 else { return nil }
             return value as? Deeplinkable.Type
+        })
+        
+        guard let type = responders.sorted(by: { (lhs, rhs) -> Bool in
+            lhs.priority.rawValue > rhs.priority.rawValue
         }).first else { return nil }
         return type
     }

--- a/MERLin/MERLin/Deeplinking/Deeplink.swift
+++ b/MERLin/MERLin/Deeplinking/Deeplink.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 
+public enum DeeplinkMatchingPriority: Int {
+    case veryLow
+    case low
+    case medium
+    case high
+    case veryHigh
+}
+
 /**
  Make a Module subclass conforming this protocol to make that module
  automatically deeplinkable. The principle behind this automatic implementation
@@ -32,6 +40,8 @@ import Foundation
 }
 
 public protocol Deeplinkable: DeeplinkResponder {
+    static var priority: DeeplinkMatchingPriority { get }
+    
     /// The class for the ViewController pointed by the deeplink. This can be used by the
     /// router for introspection on the current ViewControllers in the stack, to decide
     /// If a currently alive module must be updated, or if a new one must be created.
@@ -53,6 +63,7 @@ public protocol DeeplinkContextUpdatable: Deeplinkable {
 }
 
 public extension Deeplinkable {
+    public static var priority: DeeplinkMatchingPriority { return .medium }
     /**
      This method will return a new deeplink composed by the first schema name defined
      in the concrete class, plus the unmatched part of the original deeplink.

--- a/MERLin/MERLin/Info.plist
+++ b/MERLin/MERLin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
@@ -12,6 +12,7 @@ import MERLin
 class MockViewController: UIViewController {}
 
 class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
+    static var priority: DeeplinkMatchingPriority = .high
     static var deeplinkSchemaNames: [String] = ["test", "anotherTest"]
     
     var context: ModuleContext
@@ -40,9 +41,45 @@ class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
     
     static func deeplinkRegexes() -> [NSRegularExpression]? {
         let testRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
-        let testProductRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/product\\/?([0-9]+)", options: .caseInsensitive)
         let anotherTestRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
-        let anotherTestProductRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/product\\/?([0-9]+)", options: .caseInsensitive)
+        
+        return [testRegEx, anotherTestRegEx]
+    }
+}
+
+class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, Deeplinkable {
+    static var priority: DeeplinkMatchingPriority = .low
+    static var deeplinkSchemaNames: [String] = ["test", "anotherTest"]
+    
+    var context: ModuleContext
+    
+    required init(usingContext buildContext: ModuleContext) {
+        context = buildContext
+        super.init()
+    }
+    
+    func unmanagedRootViewController() -> UIViewController {
+        return MockViewController()
+    }
+    
+    static func classForDeeplinkingViewController() -> UIViewController.Type {
+        return MockViewController.self
+    }
+    
+    static func module(fromDeeplink deeplink: String) -> (AnyModule, UIViewController)? {
+        let module = LowPriorityMockDeeplinkableModule(usingContext: ModuleContext(building: MockDeeplinkable.self))
+        return (module, module.prepareRootViewController())
+    }
+    
+    func deeplinkURL() -> URL? {
+        return URL(string: "test://mock")
+    }
+    
+    static func deeplinkRegexes() -> [NSRegularExpression]? {
+        let testRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
+        let testProductRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/.*product\\/?([0-9]+)", options: .caseInsensitive)
+        let anotherTestRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
+        let anotherTestProductRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/.*product\\/?([0-9]+)", options: .caseInsensitive)
         
         return [testRegEx, testProductRegEx, anotherTestRegEx, anotherTestProductRegEx]
     }

--- a/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
@@ -42,6 +42,21 @@ class ModuleManagerTests: XCTestCase {
         XCTAssertEqual(eventsListener.registeredProducers.count, controllers.count)
     }
     
+    func testCorrectResponders() {
+        let deeplink = "test://mock/product/1234"
+        
+        let type = moduleManager.deeplinkable(fromDeeplink: deeplink)
+        XCTAssert(type == MockDeeplinkable.self)
+        
+        guard let remainder = MockDeeplinkable.remainderDeeplink(fromDeeplink: deeplink) else {
+            XCTFail()
+            return
+        }
+        
+        let secondType = moduleManager.deeplinkable(fromDeeplink: remainder)
+        XCTAssert(secondType == LowPriorityMockDeeplinkableModule.self)
+    }
+    
     func testThatItCanRetrieveTheRightViewControllerTypeForDeeplink() {
         let deeplink = "test://mock/2341234"
         let type = moduleManager.viewControllerType(fromDeeplink: deeplink)


### PR DESCRIPTION
It can happen that a deeplink can be matched by multiple modules. in this case the behaviour was undefined as the matching Deeplinkables were unsorted.

This PR adds the concept of matching priority.