### PR TITLE
Add trackViewController to notify to listeners that internal routing happened.

### DIFF
--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "1.5.4"
+    s.version = "1.6.0"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v1.5.4"
+        :tag => "v1.6.0"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.2.0'

--- a/MERLin/MERLin/Extensions/RxSwift+EventProtocol.swift
+++ b/MERLin/MERLin/Extensions/RxSwift+EventProtocol.swift
@@ -14,9 +14,19 @@ public extension ObservableType where E == EventProtocol {
         return compactMap { $0 as? T }
     }
     
+    public func exclude<T: EventProtocol>(event target: T) -> Observable<T> {
+        return listen(to: T.self)
+            .exclude(event: target)
+    }
+    
     public func capture<T: EventProtocol>(event target: T) -> Observable<T> {
         return listen(to: T.self)
             .capture(event: target)
+    }
+    
+    public func exclude<T: EventProtocol, Payload>(event pattern: @escaping (Payload) -> T) -> Observable<T> {
+        return listen(to: T.self)
+            .exclude(event: pattern)
     }
     
     public func capture<T: EventProtocol, Payload>(event pattern: @escaping (Payload) -> T) -> Observable<Payload> {
@@ -26,8 +36,16 @@ public extension ObservableType where E == EventProtocol {
 }
 
 public extension ObservableType where E: EventProtocol {
+    public func exclude(event target: E) -> Observable<E> {
+        return filter { !$0.matches(event: target) }
+    }
+    
     public func capture(event target: E) -> Observable<E> {
         return filter { $0.matches(event: target) }
+    }
+    
+    public func exclude<Payload>(event pattern: @escaping (Payload) -> E) -> Observable<E> {
+        return filter { $0.extractPayload(ifMatches: pattern) == nil }
     }
     
     public func capture<Payload>(event pattern: @escaping (Payload) -> E) -> Observable<Payload> {

--- a/MERLin/MERLin/Info.plist
+++ b/MERLin/MERLin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.4</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MERLin/MERLin/Module.swift
+++ b/MERLin/MERLin/Module.swift
@@ -8,18 +8,36 @@
 
 import RxSwift
 
-public enum ViewControllerEvent: EventProtocol {
+public enum ViewControllerEvent: EventProtocol, Equatable {
     case uninitialized
     case initialized
     case appeared
     case disappeared
+    
+    case newViewController(UIViewController & PageRepresenting, events: Observable<ViewControllerEvent>)
+    
+    public static func == (lhs: ViewControllerEvent, rhs: ViewControllerEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.uninitialized, .uninitialized),
+             (.initialized, .initialized),
+             (.appeared, .appeared),
+             (.disappeared, .disappeared): return true
+        case let (.newViewController(lhsController, _), .newViewController(rhsController, _)): return lhsController == rhsController
+        default: return false
+        }
+    }
 }
 
+public protocol PageRepresenting: class {
+    var pageName: String { get }
+    var section: String { get }
+    var type: String { get }
+}
 
 public protocol AnyModule: class, NSObjectProtocol {
     var viewControllerEvent: Observable<ViewControllerEvent> { get }
     var routingContext: String { get }
-
+    
     func unmanagedRootViewController() -> UIViewController
 }
 
@@ -41,7 +59,7 @@ private class ViewControllerWrapper {
 
 private var viewControllerEventHandle: UInt8 = 0
 private var viewControllerHandle: UInt8 = 0
-private var disposeBagHandle:UInt8 = 0
+private var disposeBagHandle: UInt8 = 0
 public extension AnyModule {
     public internal(set) var rootViewController: UIViewController? {
         get {
@@ -67,7 +85,7 @@ public extension AnyModule {
         }
         return observable
     }
-
+    
     public var disposeBag: DisposeBag {
         guard let bag = objc_getAssociatedObject(self, &disposeBagHandle) as? DisposeBag else {
             let bag = DisposeBag()
@@ -81,19 +99,29 @@ public extension AnyModule {
         guard rootViewController == nil else { return rootViewController! }
         let controller = unmanagedRootViewController()
         rootViewController = controller
-        
         _viewControllerEvent.onNext(.initialized)
-        let didAppearProducer = controller.rx.sentMessage(#selector(UIViewController.viewDidAppear(_:)))
+        bindViewController(controller, to: _viewControllerEvent)
+        return controller
+    }
+    
+    private func bindViewController(_ viewController: UIViewController, to events: BehaviorSubject<ViewControllerEvent>) {
+        let didAppearProducer = (viewController as UIViewController).rx.sentMessage(#selector(UIViewController.viewDidAppear(_:)))
             .map { _ in ViewControllerEvent.appeared }
         
-        let didDisappearProducer = controller.rx.sentMessage(#selector(UIViewController.viewDidDisappear(_:)))
+        let didDisappearProducer = (viewController as UIViewController).rx.sentMessage(#selector(UIViewController.viewDidDisappear(_:)))
             .map { _ in ViewControllerEvent.disappeared }
         
         Observable.of(didAppearProducer, didDisappearProducer)
             .merge()
-            .bind(to: _viewControllerEvent)
+            .bind(to: events)
             .disposed(by: disposeBag)
-        
-        return controller
+    }
+    
+    /// Call this function to send an event to all your listeners to notify that an internal routing is happening
+    /// for the current module.
+    public func trackViewController(viewController: UIViewController & PageRepresenting) {
+        let events = BehaviorSubject<ViewControllerEvent>(value: .initialized)
+        bindViewController(viewController, to: events)
+        _viewControllerEvent.onNext(.newViewController(viewController, events: events))
     }
 }

--- a/MERLin/MERLinTests/Tests/Events/ViewControllerEventsTests.swift
+++ b/MERLin/MERLinTests/Tests/Events/ViewControllerEventsTests.swift
@@ -11,6 +11,12 @@ import RxSwift
 import RxTest
 import XCTest
 
+class MockPageViewController: UIViewController, PageRepresenting {
+    var pageName: String = "MockPage"
+    var section: String = "Test"
+    var type: String = "Mock"
+}
+
 class ViewControllerEventsTests: XCTestCase {
     var disposeBag: DisposeBag!
     var module: MockModule!
@@ -111,6 +117,86 @@ class ViewControllerEventsTests: XCTestCase {
             .next(1, .initialized),
             .next(1, .appeared),
             .next(2, .disappeared)
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
+    }
+    
+    func testThatItCanHaveNewViewController() {
+        let observer = makeObserverAndSubscribe()
+        let expectedController = MockPageViewController()
+        var controller: UIViewController!
+        scheduler.scheduleAt(1) {
+            controller = self.module.prepareRootViewController()
+            controller.viewDidAppear(false)
+        }
+        scheduler.scheduleAt(2) {
+            self.module.trackViewController(viewController: expectedController)
+            controller.viewDidDisappear(false)
+        }
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(0, ViewControllerEvent.uninitialized),
+            .next(1, .initialized),
+            .next(1, .appeared),
+            .next(2, .newViewController(expectedController, events: .empty())),
+            .next(2, .disappeared)
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
+    }
+    
+    func testThatCanHaveNewViewControllerEvents() {
+        struct EventContainer: Equatable {
+            var event: ViewControllerEvent
+            var pageName: String
+            var section: String
+            var type: String
+            init(_ event: ViewControllerEvent, _ pageName: String, _ section: String, _ type: String) {
+                self.event = event
+                self.pageName = pageName
+                self.section = section
+                self.type = type
+            }
+        }
+        
+        let observer = scheduler.createObserver(EventContainer.self)
+        
+        Observable.merge(
+            module.viewControllerEvent
+                .exclude(event: ViewControllerEvent.newViewController)
+                .map { [unowned self] in EventContainer($0, self.module.moduleName, self.module.moduleSection, self.module.moduleType) },
+            module.viewControllerEvent.capture(event: ViewControllerEvent.newViewController)
+                .flatMap { (vc, obs) in obs.map { EventContainer($0, vc.pageName, vc.section, vc.type) } }
+        ).subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        let expectedController = MockPageViewController()
+        var controller: UIViewController!
+        scheduler.scheduleAt(1) {
+            controller = self.module.prepareRootViewController()
+            controller.viewDidAppear(false)
+        }
+        scheduler.scheduleAt(2) {
+            self.module.trackViewController(viewController: expectedController)
+            controller.viewDidDisappear(false)
+            expectedController.viewDidAppear(false)
+        }
+        scheduler.scheduleAt(3) {
+            expectedController.viewDidDisappear(false)
+        }
+        
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(0, EventContainer(.uninitialized, module!.moduleName, module!.moduleSection, module!.moduleType)),
+            .next(1, EventContainer(.initialized, module!.moduleName, module!.moduleSection, module!.moduleType)),
+            .next(1, EventContainer(.appeared, module!.moduleName, module!.moduleSection, module!.moduleType)),
+            .next(2, EventContainer(.initialized, expectedController.pageName, expectedController.section, expectedController.type)),
+            .next(2, EventContainer(.disappeared, module!.moduleName, module!.moduleSection, module!.moduleType)),
+            .next(2, EventContainer(.appeared, expectedController.pageName, expectedController.section, expectedController.type)),
+            .next(3, EventContainer(.disappeared, expectedController.pageName, expectedController.section, expectedController.type))
         ]
         
         XCTAssertEqual(observer.events, expected)


### PR DESCRIPTION
This PR adds the possibility to notify to listeners that a new view controller was pushed, due to internal routing of the module.

a new viewController event will be sent to the listeners featuring the new view controller and its events layer.

Check unit tests for the usage.

Added an `exclude` method for Observables of events, to capture all the events, except a specific one.