### PR TITLE
Expose default implementation of remainderDeeplink(fromDeeplink:)

### DIFF
--- a/MERLin/MERLin/Deeplinking/Deeplink.swift
+++ b/MERLin/MERLin/Deeplinking/Deeplink.swift
@@ -76,6 +76,10 @@ public extension Deeplinkable {
     public static var priority: DeeplinkMatchingPriority { return .medium }
     
     public static func remainderDeeplink(fromDeeplink deeplink: String) -> String? {
+        return defaultRemainderDeeplink(fromDeeplink: deeplink)
+    }
+    
+    public static func defaultRemainderDeeplink(fromDeeplink deeplink: String) -> String? {
         let optionalSchema = deeplinkSchemaNames.first {
             return deeplink.hasPrefix($0)
         }


### PR DESCRIPTION
Allow the developer to get access to the default implementation of `remainderDeeplink(fromDeeplink:)` even if they choose to override the method.