### PR TITLE
Deeplinks can now be delivered with user infos to their modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: osx
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 podfile: ./MERLin/Podfile
 xcode_workspace: ./MERLin/MERLin.xcworkspace
 xcode_scheme: MERLin

--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "1.7.5"
+    s.version = "1.8.0"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v1.7.5"
+        :tag => "v1.8.0"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.2.0'

--- a/MERLin/MERLin/BaseModuleManager.swift
+++ b/MERLin/MERLin/BaseModuleManager.swift
@@ -83,14 +83,14 @@ extension BaseModuleManager: DeeplinkManaging {
         return type.classForDeeplinkingViewController()
     }
     
-    @discardableResult public func update(viewController: UIViewController, fromDeeplink deeplink: String) -> Bool {
+    @discardableResult public func update(viewController: UIViewController, fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
         guard let module = self.module(for: viewController) as? DeeplinkContextUpdatable else { return false }
-        return module.updateContext(fromDeeplink: deeplink)
+        return module.updateContext(fromDeeplink: deeplink, userInfo: userInfo)
     }
     
-    public func viewController(fromDeeplink deeplink: String) -> UIViewController? {
+    public func viewController(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> UIViewController? {
         guard let type = deeplinkable(fromDeeplink: deeplink) else { return nil }
-        guard let (module, controller) = type.module(fromDeeplink: deeplink) else { return nil }
+        guard let (module, controller) = type.module(fromDeeplink: deeplink, userInfo: userInfo) else { return nil }
         moduleRetainer.set(ModuleWrapper(module), forKey: controller)
         setupEventsListeners(for: module)
         return controller

--- a/MERLin/MERLin/Deeplinking/Deeplink.swift
+++ b/MERLin/MERLin/Deeplinking/Deeplink.swift
@@ -58,7 +58,7 @@ public protocol Deeplinkable: DeeplinkResponder {
     static func classForDeeplinkingViewController() -> UIViewController.Type
     
     /// Instanciate a module and the viewController associated to a specified deeplink.
-    static func module(fromDeeplink deeplink: String) -> (AnyModule, UIViewController)?
+    static func module(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> (AnyModule, UIViewController)?
     
     /// For living modules, this method will return the deeplink to recreate self
     /// with the same buildContext (if any).
@@ -69,7 +69,7 @@ public protocol DeeplinkContextUpdatable: Deeplinkable {
     /// This method will update the context of an existing module using a deeplink.
     /// If the module cannot handle the request for any reason the return value of this
     /// method will be false.
-    @discardableResult func updateContext(fromDeeplink deeplink: String) -> Bool
+    @discardableResult func updateContext(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool
 }
 
 public extension Deeplinkable {
@@ -89,6 +89,11 @@ public extension Deeplinkable {
             let range = Range(match.range(at: 0), in: deeplink) else { return nil }
         
         let remainder = String(deeplink.suffix(from: range.upperBound))
+            .split(separator: "/")
+            .filter { !$0.isEmpty }
+            .map(String.init)
+            .joined(separator: "/")
+        
         guard remainder.count > 0 && remainder != "/" else { return nil }
         
         let resultingDeeplink = "\(schema)://\(remainder)".replacingOccurrences(of: "///", with: "//")

--- a/MERLin/MERLin/Deeplinking/DeeplinkManaging.swift
+++ b/MERLin/MERLin/Deeplinking/DeeplinkManaging.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol DeeplinkManaging: class {
     func viewControllerType(fromDeeplink deeplink: String) -> UIViewController.Type?
-    @discardableResult func update(viewController: UIViewController, fromDeeplink deeplink: String) -> Bool
-    func viewController(fromDeeplink deeplink: String) -> UIViewController?
+    @discardableResult func update(viewController: UIViewController, fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool
+    func viewController(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> UIViewController?
     func unmatchedDeeplinkRemainder(fromDeeplink deeplink: String) -> String?
 }

--- a/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
@@ -30,7 +30,7 @@ class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
         return MockViewController.self
     }
     
-    static func module(fromDeeplink deeplink: String) -> (AnyModule, UIViewController)? {
+    static func module(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> (AnyModule, UIViewController)? {
         let module = MockDeeplinkable(usingContext: ModuleContext(building: MockDeeplinkable.self))
         return (module, module.prepareRootViewController())
     }
@@ -66,7 +66,7 @@ class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, DeeplinkConte
         return MockViewController.self
     }
     
-    static func module(fromDeeplink deeplink: String) -> (AnyModule, UIViewController)? {
+    static func module(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> (AnyModule, UIViewController)? {
         let module = LowPriorityMockDeeplinkableModule(usingContext: ModuleContext(building: MockDeeplinkable.self))
         return (module, module.prepareRootViewController())
     }
@@ -84,7 +84,7 @@ class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, DeeplinkConte
         return [testRegEx, testProductRegEx, anotherTestRegEx, anotherTestProductRegEx]
     }
     
-    func updateContext(fromDeeplink deeplink: String) -> Bool {
+    func updateContext(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
         return !deeplink.contains("mock")
     }
 }

--- a/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
@@ -71,7 +71,7 @@ class ModuleManagerTests: XCTestCase {
     
     func testItCanGetAViewControllerForDeeplink() {
         let deeplink = "test://mock/2341234"
-        guard let viewController = moduleManager.viewController(fromDeeplink: deeplink) else {
+        guard let viewController = moduleManager.viewController(fromDeeplink: deeplink, userInfo: nil) else {
             XCTFail()
             return
         }
@@ -80,7 +80,7 @@ class ModuleManagerTests: XCTestCase {
     
     func testItCanFailRetrievingAViewController() {
         let deeplink = "test://failing/deeplink"
-        let viewController = moduleManager.viewController(fromDeeplink: deeplink)
+        let viewController = moduleManager.viewController(fromDeeplink: deeplink, userInfo: nil)
         XCTAssertNil(viewController)
     }
     

--- a/MERLin/MERLinTests/Tests/Router/RouterTests.swift
+++ b/MERLin/MERLinTests/Tests/Router/RouterTests.swift
@@ -110,7 +110,7 @@ class RouterTests: XCTestCase {
     
     func testSimpleDeeplink() {
         let deeplink = "test://mock/"
-        let controller = router.route(toDeeplink: deeplink)
+        let controller = router.route(toDeeplink: deeplink, userInfo: nil)
         
         XCTAssert(controller is UINavigationController)
         XCTAssert((controller as? UINavigationController)?.viewControllers.first is MockViewController)
@@ -118,7 +118,7 @@ class RouterTests: XCTestCase {
     
     func testSmartDeeplink() {
         let deeplink = "test://mock/product/1234"
-        let controller = router.route(toDeeplink: deeplink)
+        let controller = router.route(toDeeplink: deeplink, userInfo: nil)
         
         XCTAssertEqual((controller as? UINavigationController)?.viewControllers.count, 2)
     }
@@ -142,7 +142,7 @@ class RouterTests: XCTestCase {
         let (tabBarRouter, _, _) = setupTabBarRootViewController()
         
         let deeplink = "test://mock/"
-        let controller = tabBarRouter.route(toDeeplink: deeplink)
+        let controller = tabBarRouter.route(toDeeplink: deeplink, userInfo: nil)
         
         XCTAssert(controller is UINavigationController)
         XCTAssert((controller as? UINavigationController)?.viewControllers.first is MockViewController)
@@ -152,7 +152,7 @@ class RouterTests: XCTestCase {
         let (tabBarRouter, _, updatable) = setupTabBarRootViewController()
         
         let deeplink = "test://product/1234"
-        let controller = tabBarRouter.route(toDeeplink: deeplink)
+        let controller = tabBarRouter.route(toDeeplink: deeplink, userInfo: nil)
         
         XCTAssertEqual(controller, tabBarRouter.topViewController)
         XCTAssertEqual((controller as? UITabBarController)?.selectedIndex, 1)
@@ -161,7 +161,7 @@ class RouterTests: XCTestCase {
     
     func testItCanPushFromCurrentContext() {
         let deeplink = "test://mock/"
-        let controller = router.handleDeeplink(deeplink, shouldPush: true)
+        let controller = router.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
         
         XCTAssertEqual(controller, router.topViewController)
         XCTAssertEqual((controller as? UINavigationController)?.viewControllers.count, 2)
@@ -181,7 +181,7 @@ class RouterTests: XCTestCase {
             tabbarController.selectedIndex = index
             XCTAssertEqual((tabbarController.selectedViewController as? UINavigationController)?.viewControllers.count, 1)
             
-            let controller = tabBarRouter.handleDeeplink(deeplink, shouldPush: true)
+            let controller = tabBarRouter.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
             
             XCTAssertEqual(controller, tabbarController)
             XCTAssertEqual((tabbarController.selectedViewController as? UINavigationController)?.viewControllers.count, 2)
@@ -192,7 +192,7 @@ class RouterTests: XCTestCase {
         let (tabBarRouter, _, _) = setupTabBarRootViewController()
         let deeplink = "test://mock/product/1234"
         
-        let controller = tabBarRouter.handleDeeplink(deeplink, shouldPush: true)
+        let controller = tabBarRouter.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
         
         XCTAssertEqual(controller, tabBarRouter.topViewController)
         XCTAssertEqual((controller as? UITabBarController)?.selectedIndex, 0)


### PR DESCRIPTION
The default router will push the same user info to all the chain of modules created by a smart Deeplink.