### PR TITLE
Removed PageInfo and PageRepresentable

### DIFF
--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "1.9.4"
+    s.version = "2.0.0"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v1.9.4"
+        :tag => "v2.0.0"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.3.2'

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		502E0E6921D3A8C5004A4F56 /* RxExtension+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E0E6821D3A8C5004A4F56 /* RxExtension+String.swift */; };
 		5074DF31213ECD010021294D /* DeeplinkMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 501D6F802130BD3600114F5A /* DeeplinkMatcher.m */; };
 		5074DF32213ECD010021294D /* DeeplinkMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 501D6F812130BD3600114F5A /* DeeplinkMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5081B7BE22BB964300F46EBB /* ViewControllerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5081B7BD22BB964300F46EBB /* ViewControllerEvent.swift */; };
 		50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */; };
 		50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11870213BF89E008928AF /* ModuleManagerTests.swift */; };
 		50B11873213BF89E008928AF /* DeeplinkableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11871213BF89E008928AF /* DeeplinkableTests.swift */; };
@@ -110,6 +111,7 @@
 		502E0E6421D2FF29004A4F56 /* RxExtensionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxExtensionTestCase.swift; sourceTree = "<group>"; };
 		502E0E6621D2FF9F004A4F56 /* BoolRxExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolRxExtensionTests.swift; sourceTree = "<group>"; };
 		502E0E6821D3A8C5004A4F56 /* RxExtension+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxExtension+String.swift"; sourceTree = "<group>"; };
+		5081B7BD22BB964300F46EBB /* ViewControllerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerEvent.swift; sourceTree = "<group>"; };
 		50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxSwift+EventProtocol.swift"; sourceTree = "<group>"; };
 		50B11870213BF89E008928AF /* ModuleManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleManagerTests.swift; sourceTree = "<group>"; };
 		50B11871213BF89E008928AF /* DeeplinkableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeeplinkableTests.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				501D6F982130BD3700114F5A /* EventsListening.swift */,
 				501D6F992130BD3700114F5A /* EventsProducer.swift */,
 				501D6F9A2130BD3700114F5A /* EventProtocol.swift */,
+				5081B7BD22BB964300F46EBB /* ViewControllerEvent.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -325,7 +328,6 @@
 				889548098BFC628D8FE0220D /* Pods-MERLinTests.test.xcconfig */,
 				B53368DBFA8F143CE9A5FF51 /* Pods-MERLinTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -531,6 +533,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				501D6FA02130BD3800114F5A /* DisplayingError.swift in Sources */,
+				5081B7BE22BB964300F46EBB /* ViewControllerEvent.swift in Sources */,
 				501D6F702130BD1200114F5A /* BaseModuleManager.swift in Sources */,
 				501D6FA22130BD3800114F5A /* PresentableRoutingStep.swift in Sources */,
 				501D6FA12130BD3800114F5A /* ViewControllerBuilding.swift in Sources */,

--- a/MERLin/MERLin/Events/ViewControllerEvent.swift
+++ b/MERLin/MERLin/Events/ViewControllerEvent.swift
@@ -1,0 +1,49 @@
+//
+//  ViewControllerEvent.swift
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 20/06/2019.
+//  Copyright © 2019 Giuseppe Lanza. All rights reserved.
+//
+
+import RxSwift
+
+public enum ViewControllerEvent: EventProtocol, Equatable {
+    case willAppear
+    case appeared
+    case willDisappear
+    case disappeared
+}
+
+private var viewControllerEventHandle: UInt8 = 0
+public extension UIViewController {
+    var events: Observable<ViewControllerEvent> {
+        guard let observable = objc_getAssociatedObject(self, &viewControllerEventHandle) as? Observable<ViewControllerEvent> else {
+            let observable = makeVCEvents()
+            objc_setAssociatedObject(self, &viewControllerEventHandle, observable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            return observable
+        }
+        return observable
+    }
+    
+    private func makeVCEvents() -> Observable<ViewControllerEvent> {
+        let willAppearProducer = rx.sentMessage(#selector(UIViewController.viewWillAppear(_:)))
+            .map { _ in ViewControllerEvent.willAppear }
+        
+        let didAppearProducer = rx.sentMessage(#selector(UIViewController.viewDidAppear(_:)))
+            .map { _ in ViewControllerEvent.appeared }
+        
+        let willDisappearProducer = rx.sentMessage(#selector(UIViewController.viewWillDisappear(_:)))
+            .map { _ in ViewControllerEvent.willDisappear }
+        
+        let didDisappearProducer = rx.sentMessage(#selector(UIViewController.viewDidDisappear(_:)))
+            .map { _ in ViewControllerEvent.disappeared }
+        
+        return Observable.merge(
+            willAppearProducer,
+            didAppearProducer,
+            willDisappearProducer,
+            didDisappearProducer
+        )
+    }
+}

--- a/MERLin/MERLin/Info.plist
+++ b/MERLin/MERLin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.3</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MERLin/MERLinTests/Mocks/MockModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockModule.swift
@@ -30,12 +30,8 @@ class ContextualizedMockModule: NSObject, ModuleProtocol {
     }
 }
 
-class MockModule: NSObject, ModuleProtocol, EventsProducer, PageRepresenting {
+class MockModule: NSObject, ModuleProtocol, EventsProducer {
     var context: ModuleContext
-    
-    var pageName: String = "MockModule"
-    var section: String = "ModuleTests"
-    var pageType: String = "test"
     
     var events: Observable<NoEvents> = PublishSubject<NoEvents>()
     required init(usingContext buildContext: ModuleContext) {

--- a/MERLin/MERLinTests/Tests/Events/ViewControllerEventsTests.swift
+++ b/MERLin/MERLinTests/Tests/Events/ViewControllerEventsTests.swift
@@ -11,28 +11,21 @@ import RxSwift
 import RxTest
 import XCTest
 
-class MockPageViewController: UIViewController, PageRepresenting {
-    var pageName: String = "MockPage"
-    var section: String = "Test"
-    var pageType: String = "Mock"
-}
-
 class ViewControllerEventsTests: XCTestCase {
     var disposeBag: DisposeBag!
-    var module: MockModule!
+    var viewController: MockViewController!
     var scheduler: TestScheduler!
     
     override func setUp() {
         super.setUp()
         disposeBag = DisposeBag()
-        let context = ModuleContext(routingContext: "mock", building: MockModule.self)
-        module = MockModule(usingContext: context)
+        viewController = MockViewController()
         scheduler = TestScheduler(initialClock: 0)
     }
     
     override func tearDown() {
         disposeBag = nil
-        module = nil
+        viewController = nil
         scheduler = nil
         super.tearDown()
     }
@@ -40,7 +33,7 @@ class ViewControllerEventsTests: XCTestCase {
     func makeObserverAndSubscribe() -> TestableObserver<ViewControllerEvent> {
         let observer = scheduler.createObserver(ViewControllerEvent.self)
         
-        module.viewControllerEvent
+        viewController.events
             .subscribe(observer)
             .disposed(by: disposeBag)
         
@@ -48,53 +41,22 @@ class ViewControllerEventsTests: XCTestCase {
     }
     
     func testThatItCanStoreTheObservable() {
-        let observable = module.viewControllerEvent
-        XCTAssertTrue(observable === module.viewControllerEvent)
-    }
-    
-    func testThatInitialStateIsUninitialised() {
-        let observer = makeObserverAndSubscribe()
-        scheduler.start()
-        
-        let expected = [
-            Recorded.next(0, ViewControllerEvent.uninitialized)
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
-    }
-    
-    func testThatStateChangeToInitialised() {
-        let observer = makeObserverAndSubscribe()
-        scheduler.scheduleAt(1) {
-            _ = self.module.prepareRootViewController()
-        }
-        
-        scheduler.start()
-        
-        let expected = [
-            Recorded.next(0, ViewControllerEvent.uninitialized),
-            .next(1, .initialized),
-            .completed(1) // ViewControlelr dies so it causes the completed.
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
+        let observable = viewController.events
+        XCTAssertTrue(observable === viewController.events)
     }
     
     func testThatStateChangeToAppeared() {
         let observer = makeObserverAndSubscribe()
-        var controller: UIViewController!
+        
         scheduler.scheduleAt(1) {
-            controller = self.module.prepareRootViewController()
-        }
-        scheduler.scheduleAt(2) {
-            controller.viewDidAppear(false)
+            self.viewController.viewWillAppear(false)
+            self.viewController.viewDidAppear(false)
         }
         scheduler.start()
         
         let expected = [
-            Recorded.next(0, ViewControllerEvent.uninitialized),
-            .next(1, .initialized),
-            .next(2, .appeared)
+            Recorded.next(1, ViewControllerEvent.willAppear),
+            .next(1, .appeared)
         ]
         
         XCTAssertEqual(observer.events, expected)
@@ -102,101 +64,19 @@ class ViewControllerEventsTests: XCTestCase {
     
     func testThatItCanChangeToDisappeared() {
         let observer = makeObserverAndSubscribe()
-        var controller: UIViewController!
         scheduler.scheduleAt(1) {
-            controller = self.module.prepareRootViewController()
-            controller.viewDidAppear(false)
+            self.viewController.viewDidAppear(false)
         }
         scheduler.scheduleAt(2) {
-            controller.viewDidDisappear(false)
+            self.viewController.viewWillDisappear(false)
+            self.viewController.viewDidDisappear(false)
         }
         scheduler.start()
         
         let expected = [
-            Recorded.next(0, ViewControllerEvent.uninitialized),
-            .next(1, .initialized),
-            .next(1, .appeared),
+            Recorded.next(1, ViewControllerEvent.appeared),
+            .next(2, .willDisappear),
             .next(2, .disappeared)
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
-    }
-    
-    func testThatItCanHaveNewViewController() {
-        let observer = makeObserverAndSubscribe()
-        let expectedController = MockPageViewController()
-        var controller: UIViewController!
-        scheduler.scheduleAt(1) {
-            controller = self.module.prepareRootViewController()
-            controller.viewDidAppear(false)
-        }
-        scheduler.scheduleAt(2) {
-            self.module.trackViewController(viewController: expectedController)
-            controller.viewDidDisappear(false)
-        }
-        scheduler.start()
-        
-        let expected = [
-            Recorded.next(0, ViewControllerEvent.uninitialized),
-            .next(1, .initialized),
-            .next(1, .appeared),
-            .next(2, .newViewController(PageInfo(withPage: expectedController), events: .empty())),
-            .next(2, .disappeared)
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
-    }
-    
-    func testThatCanHaveNewViewControllerEvents() {
-        struct EventContainer: Equatable {
-            var event: ViewControllerEvent
-            var pageName: String
-            var section: String
-            var type: String
-            init(_ event: ViewControllerEvent, _ pageName: String, _ section: String, _ type: String) {
-                self.event = event
-                self.pageName = pageName
-                self.section = section
-                self.type = type
-            }
-        }
-        
-        let observer = scheduler.createObserver(EventContainer.self)
-        
-        Observable.merge(
-            module.viewControllerEvent
-                .exclude(event: ViewControllerEvent.newViewController)
-                .map { [unowned self] in EventContainer($0, self.module.pageName, self.module.section, self.module.pageType) },
-            module.viewControllerEvent.capture(event: ViewControllerEvent.newViewController)
-                .flatMap { (vc, obs) in obs.map { EventContainer($0, vc.pageName, vc.section, vc.pageType) } }
-        ).subscribe(observer)
-            .disposed(by: disposeBag)
-        
-        let expectedController = MockPageViewController()
-        var controller: UIViewController!
-        scheduler.scheduleAt(1) {
-            controller = self.module.prepareRootViewController()
-            controller.viewDidAppear(false)
-        }
-        scheduler.scheduleAt(2) {
-            self.module.trackViewController(viewController: expectedController)
-            controller.viewDidDisappear(false)
-            expectedController.viewDidAppear(false)
-        }
-        scheduler.scheduleAt(3) {
-            expectedController.viewDidDisappear(false)
-        }
-        
-        scheduler.start()
-        
-        let expected = [
-            Recorded.next(0, EventContainer(.uninitialized, module!.pageName, module!.section, module!.pageType)),
-            .next(1, EventContainer(.initialized, module!.pageName, module!.section, module!.pageType)),
-            .next(1, EventContainer(.appeared, module!.pageName, module!.section, module!.pageType)),
-            .next(2, EventContainer(.initialized, expectedController.pageName, expectedController.section, expectedController.pageType)),
-            .next(2, EventContainer(.disappeared, module!.pageName, module!.section, module!.pageType)),
-            .next(2, EventContainer(.appeared, expectedController.pageName, expectedController.section, expectedController.pageType)),
-            .next(3, EventContainer(.disappeared, expectedController.pageName, expectedController.section, expectedController.pageType))
         ]
         
         XCTAssertEqual(observer.events, expected)

--- a/MERLin/MERLinTests/Tests/Modules/ModuleTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleTests.swift
@@ -149,8 +149,12 @@ class ModuleTests: XCTestCase {
     }
     
     struct VCEvent: Equatable {
-        var vc: UIViewController
-        var ev: ViewControllerEvent
+        var controller: UIViewController
+        var event: ViewControllerEvent
+        init(_ controller: UIViewController, _ event: ViewControllerEvent) {
+            self.controller = controller
+            self.event = event
+        }
     }
     
     func testViewControllerFlowScenario() {
@@ -186,12 +190,12 @@ class ModuleTests: XCTestCase {
         scheduler.start()
         
         let expected = [
-            Recorded.next(1, VCEvent(vc: root, ev: .willAppear)),
-            .next(1, VCEvent(vc: root, ev: .appeared)),
-            .next(3, VCEvent(vc: root, ev: .willDisappear)),
-            .next(3, VCEvent(vc: newVC, ev: .willAppear)),
-            .next(3, VCEvent(vc: root, ev: .disappeared)),
-            .next(3, VCEvent(vc: newVC, ev: .appeared))
+            Recorded.next(1, VCEvent(root, .willAppear)),
+            .next(1, VCEvent(root, .appeared)),
+            .next(3, VCEvent(root, .willDisappear)),
+            .next(3, VCEvent(newVC, .willAppear)),
+            .next(3, VCEvent(root, .disappeared)),
+            .next(3, VCEvent(newVC, .appeared))
         ]
         
         XCTAssertEqual(observer.events, expected)

--- a/MERLin/MERLinTests/Tests/Modules/ModuleTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleTests.swift
@@ -6,20 +6,28 @@
 //  Copyright © 2019 Giuseppe Lanza. All rights reserved.
 //
 
-import XCTest
 @testable import MERLin
+import RxSwift
+import RxTest
+import XCTest
 
 class ModuleTests: XCTestCase {
     var module: MockModule!
+    var scheduler: TestScheduler!
+    var disposeBag: DisposeBag!
+    
     override func setUp() {
         super.setUp()
         module = MockModule(usingContext: ModuleContext(building: MockModule.self))
+        scheduler = TestScheduler(initialClock: 0)
+        disposeBag = DisposeBag()
     }
     
     override func tearDown() {
         module = nil
         super.tearDown()
     }
+    
     func testItCanStoreRootViewController() {
         let viewController = UIViewController()
         module.rootViewController = viewController
@@ -56,5 +64,136 @@ class ModuleTests: XCTestCase {
         let disposeBag = module.disposeBag
         let cachedDisposeBag = module.disposeBag
         XCTAssert(disposeBag === cachedDisposeBag)
+    }
+    
+    func testThatNewViewControllerObservableIsUnique() {
+        let observable = module.newViewControllers
+        XCTAssert(observable === module.newViewControllers)
+    }
+    
+    func testThatNewViewControllerEmitsRootViewControllerAsInitialValue() {
+        let expectedVC = module.prepareRootViewController()
+        
+        let observer = scheduler.createObserver(UIViewController.self)
+        
+        module.newViewControllers
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(0, expectedVC)
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
+    }
+    
+    func testThatNewViewControllerEmitsRootViewController() {
+        let observer = scheduler.createObserver(UIViewController.self)
+        var expectedVC: UIViewController!
+        module.newViewControllers
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        scheduler.scheduleAt(1) {
+            expectedVC = self.module.prepareRootViewController()
+        }
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(1, expectedVC!)
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
+    }
+    
+    func testThatNewViewControllerDoesNotRetainViewControllers() {
+        autoreleasepool { _ = module.prepareRootViewController() }
+        // It's proved by previous tests that at this point the observable
+        // exists and an event is already sent with the rootViewController
+        
+        let observer = scheduler.createObserver(UIViewController.self)
+        
+        module.newViewControllers
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        scheduler.start()
+        
+        XCTAssertEqual(observer.events, [])
+    }
+    
+    func testThatModuleCanEmitNewViewControllers() {
+        let root = module.prepareRootViewController()
+        let newVC = MockViewController()
+        
+        let observer = scheduler.createObserver(UIViewController.self)
+        
+        module.newViewControllers
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        scheduler.scheduleAt(1) {
+            self.module.signalNew(viewController: newVC)
+        }
+        
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(0, root),
+            .next(1, newVC)
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
+    }
+    
+    struct VCEvent: Equatable {
+        var vc: UIViewController
+        var ev: ViewControllerEvent
+    }
+    
+    func testViewControllerFlowScenario() {
+        let root = module.prepareRootViewController()
+        let newVC = MockViewController()
+        
+        let observer = scheduler.createObserver(VCEvent.self)
+        
+        module.newViewControllers
+            .flatMap { controller in
+                controller.events
+                    .map { (controller, $0) }
+                    .map(VCEvent.init) // In real world applications i suggest to capture an identifier
+            }.subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        scheduler.scheduleAt(1) {
+            root.viewWillAppear(false)
+            root.viewDidAppear(false)
+        }
+        
+        scheduler.scheduleAt(2) {
+            self.module.signalNew(viewController: newVC)
+        }
+        
+        scheduler.scheduleAt(3) {
+            root.viewWillDisappear(false)
+            newVC.viewWillAppear(false)
+            root.viewDidDisappear(false)
+            newVC.viewDidAppear(false)
+        }
+        
+        scheduler.start()
+        
+        let expected = [
+            Recorded.next(1, VCEvent(vc: root, ev: .willAppear)),
+            .next(1, VCEvent(vc: root, ev: .appeared)),
+            .next(3, VCEvent(vc: root, ev: .willDisappear)),
+            .next(3, VCEvent(vc: newVC, ev: .willAppear)),
+            .next(3, VCEvent(vc: root, ev: .disappeared)),
+            .next(3, VCEvent(vc: newVC, ev: .appeared))
+        ]
+        
+        XCTAssertEqual(observer.events, expected)
     }
 }

--- a/MERLinSample/MERLinSample/EventsListeners/ConsoleLogEventsListener.swift
+++ b/MERLinSample/MERLinSample/EventsListeners/ConsoleLogEventsListener.swift
@@ -10,8 +10,8 @@ import MERLin
 
 class ConsoleLogEventsListener: AnyEventsListening {
     @discardableResult func registerToEvents(for producer: AnyEventsProducer) -> Bool {
-        let pageName = (producer as? PageRepresenting)?.pageName ?? "\(producer)"
-        producer.anyEvents.map { [weak producer] in "[\(pageName)] \($0)" }
+        let pageName = "\(type(of: producer))"
+        producer.anyEvents.map { "[\(pageName)] \($0)" }
             .subscribe(onNext: { print($0) })
             .disposed(by: producer.disposeBag)
         

--- a/MERLinSample/Podfile.lock
+++ b/MERLinSample/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - LNZWeakCollection (1.3.2)
-  - MERLin (1.9.4):
+  - MERLin (2.0.0):
     - LNZWeakCollection (~> 1.3.2)
     - RxCocoa (~> 5.0.0)
   - RxCocoa (5.0.0):
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   LNZWeakCollection: 0211da4f8778cb35d1b9fa788a3cb395e26a0226
-  MERLin: d1b7a91ca7aca09f0d6c697513943002b6a8e43e
+  MERLin: 9334adcde60fc39d32914118fa7704e9cba004a2
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
   RxSwift: 8b0671caa829a763bbce7271095859121cbd895f

--- a/MERLinSample/RestaurantDetailModule/RestaurantDetailModule.swift
+++ b/MERLinSample/RestaurantDetailModule/RestaurantDetailModule.swift
@@ -14,12 +14,8 @@ extension UIStoryboard {
     }
 }
 
-public class RestaurantDetailModule: NSObject, ModuleProtocol, EventsProducer, PageRepresenting {
+public class RestaurantDetailModule: NSObject, ModuleProtocol, EventsProducer {
     public var context: RestaurantDetailBuildContext
-    
-    public var pageName: String = "Restaurant Detail Page"
-    public var section: String = "Restaurant Detail"
-    public var pageType: String = "Detail"
     
     public var events: Observable<RestaurantDetailEvent> { return _events }
     private var _events = PublishSubject<RestaurantDetailEvent>()

--- a/MERLinSample/RestaurantsListModule/RestaurantsListModule.swift
+++ b/MERLinSample/RestaurantsListModule/RestaurantsListModule.swift
@@ -18,12 +18,8 @@ extension UIStoryboard {
     }
 }
 
-public class RestaurantsListModule: NSObject, ModuleProtocol, EventsProducer, PageRepresenting {
+public class RestaurantsListModule: NSObject, ModuleProtocol, EventsProducer {
     public var context: ModuleContext
-    
-    public var pageName: String = "Restaurants List"
-    public var section: String = "Restaurants List"
-    public var pageType: String = "List"
     
     public var events: Observable<RestaurantsListEvent> { return _events }
     private let _events = PublishSubject<RestaurantsListEvent>()


### PR DESCRIPTION
This pull request includes some deep changes to the internal routing paradigm.

## ViewControllerEvent

ViewControllerEvent is no longer part of Module. Each ViewController has now an events variable that can be accessed to log the view controller life cycle.
Any Module is not necessarily an `eventsProducer` yet, up until now it had an events bus for its root view controller lifecycle.

ViewControllerEvent also had some cases that a viewController can't technically know itself and had sense only when the viewControllerEvent was managed by the instanciator. These cases are specifically `uninitialised` and `initialised`. 

When the viewController is uninitialised then no events can possibly exist from an inexistent instance. When the viewController is initialised, clearly the sole existence of the instance is a clear indication of its initialised state. 

Another case of `ViewControllerEvent` that also was removed is the one responsible for the notification of a new view controller pushed on screen due to internal routing. Technically the last described scenario is not a view controller event related to its lifecycle. Even if the fact that a new controller is on screen impact at some extent the lifecycle of the currently observed view controller, these are side effects caused by UIKit that will be reflected in `willDisappear` and `disappeared` case.

Any module now have an observable of viewController to notify an internal routing happened.

## PageRepresentable and PageInfo
These two entity just don't have any reason to exist in MERLin. MERLin handles ViewControllers. If these ViewControllers should be recognised as specific pages for specific application logic, then PageRepresentable should be part of the specific implementation of the application itself.