### PR TITLE
Returning an array of deeplinked view controllers on route to deeplink

### DIFF
--- a/MERLin/MERLin.xcodeproj/xcshareddata/xcschemes/MERLin.xcscheme
+++ b/MERLin/MERLin.xcodeproj/xcshareddata/xcschemes/MERLin.xcscheme
@@ -24,11 +24,20 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Test"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
+            BuildableName = "MERLin.framework"
+            BlueprintName = "MERLin"
+            ReferencedContainer = "container:MERLin.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,17 +61,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "501D6F042130BB4F00114F5A"
-            BuildableName = "MERLin.framework"
-            BlueprintName = "MERLin"
-            ReferencedContainer = "container:MERLin.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -83,8 +81,6 @@
             ReferencedContainer = "container:MERLin.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -52,7 +52,6 @@ public extension Router {
     internal func currentViewController() -> UIViewController {
         var currentController = topViewController
         while let presented = currentController.presentedViewController {
-            print(presented)
             currentController = presented
         }
         return currentController
@@ -219,7 +218,7 @@ public extension Router {
     }
     
     /// If the deeplink is composed by a part that was not matched by the deeplinked controller
-    ///there might be a next deeplink path. Ex: thebay://productarray/1234/pdp/112233
+    /// there might be a next deeplink path. Ex: thebay://productarray/1234/pdp/112233
     /// would cause product array to match the first part, and to have `/pdp/112233` unmatched
     /// a new deeplink is then generated in this method to be theBay://pdp/112233 and then pushed
     @discardableResult

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -37,7 +37,7 @@ public protocol Router: AnyObject {
      */
     @discardableResult func route(to destination: PresentableRoutingStep) -> UIViewController?
     @discardableResult func route(to viewController: UIViewController, withPresentationMode mode: RoutingStepPresentationMode, animated: Bool) -> UIViewController?
-    @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> UIViewController?
+    @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> [UIViewController]?
     
     func handleShortcutItem(_ item: UIApplicationShortcutItem)
     
@@ -52,6 +52,7 @@ public extension Router {
     internal func currentViewController() -> UIViewController {
         var currentController = topViewController
         while let presented = currentController.presentedViewController {
+            print(presented)
             currentController = presented
         }
         return currentController
@@ -129,7 +130,7 @@ public extension Router {
 // MARK: Deeplink
 
 public extension Router {
-    @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> UIViewController? {
+    @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> [UIViewController]? {
         return handleDeeplink(deeplink, userInfo: userInfo)
     }
     
@@ -153,7 +154,7 @@ public extension Router {
      also ignores updatable controllers, unless the deeplink is not updatable itself from the current deeplink
      */
     @discardableResult
-    func handleDeeplink(_ deeplink: String, from: UIViewController? = nil, shouldPush: Bool = false, traverseAll: Bool = false, userInfo: [String: Any]?) -> UIViewController? {
+    func handleDeeplink(_ deeplink: String, from: UIViewController? = nil, shouldPush: Bool = false, traverseAll: Bool = false, userInfo: [String: Any]?) -> [UIViewController]? {
         guard let viewControllersFactory = viewControllersFactory,
             let controllerClass = viewControllersFactory.viewControllerType(fromDeeplink: deeplink) else {
             return nil
@@ -163,16 +164,18 @@ public extension Router {
         var currentController = from ?? currentViewController()
         
         var handled = false
-        
+        var deeplinkedController: UIViewController?
         let controllers = (currentController as? UITabBarController)?.viewControllers?.enumerated() ?? [currentController].enumerated()
         for (i, controller) in controllers {
             if controller.isMember(of: controllerClass) {
                 handled = viewControllersFactory.update(viewController: controller, fromDeeplink: deeplink, userInfo: userInfo)
+                deeplinkedController = controller
             } else if !shouldPush || traverseAll || controller == (currentController as? UITabBarController)?.selectedViewController,
                 let contained = (controller as? UINavigationController)?.viewControllers.last,
                 contained.isMember(of: controllerClass) {
                 // currentController might be a navigation controller (most likely) containing the controller class
                 handled = viewControllersFactory.update(viewController: contained, fromDeeplink: deeplink, userInfo: userInfo)
+                deeplinkedController = contained
             }
             
             if handled {
@@ -208,9 +211,11 @@ public extension Router {
                 deeplinkedViewController.navigationItem.leftBarButtonItem = closeButton(for: deeplinkedViewController, onClose: nil)
                 currentController = navigationController
             }
+            
+            deeplinkedController = deeplinkedViewController
         }
         
-        return pushUnmatched(fromDeeplink: deeplink, from: currentController, userInfo: userInfo) ?? currentController
+        return (deeplinkedController.map { [$0] } ?? []) + (pushUnmatched(fromDeeplink: deeplink, from: currentController, userInfo: userInfo) ?? [])
     }
     
     /// If the deeplink is composed by a part that was not matched by the deeplinked controller
@@ -218,7 +223,7 @@ public extension Router {
     /// would cause product array to match the first part, and to have `/pdp/112233` unmatched
     /// a new deeplink is then generated in this method to be theBay://pdp/112233 and then pushed
     @discardableResult
-    func pushUnmatched(fromDeeplink deeplink: String, from: UIViewController?, userInfo: [String: Any]?) -> UIViewController? {
+    func pushUnmatched(fromDeeplink deeplink: String, from: UIViewController?, userInfo: [String: Any]?) -> [UIViewController]? {
         guard let newDeeplink = viewControllersFactory?.unmatchedDeeplinkRemainder(fromDeeplink: deeplink) else {
             return nil
         }


### PR DESCRIPTION
the route to deeplink method now returns an array of the actually deeplinked view controllers, no longer the container of the deeplinked view controllers

The method must return an array because of the smart deeplink feature. The deeplink might point to a stack of view controllers. the order of the view controllers in the array reflect the view stack, having as last the view controller currently visible.