### PR TITLE
Add os_logs for module manager, router and events

### DIFF
--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		502E0E6521D2FF29004A4F56 /* RxExtensionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E0E6421D2FF29004A4F56 /* RxExtensionTestCase.swift */; };
 		502E0E6721D2FF9F004A4F56 /* BoolRxExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E0E6621D2FF9F004A4F56 /* BoolRxExtensionTests.swift */; };
 		502E0E6921D3A8C5004A4F56 /* RxExtension+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E0E6821D3A8C5004A4F56 /* RxExtension+String.swift */; };
+		503E60B52377019F00EE01A2 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503E60B42377019F00EE01A2 /* OSLog.swift */; };
 		504308DE22AEA789008AC2AB /* MockModuleListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504308DD22AEA789008AC2AB /* MockModuleListener.swift */; };
 		504A93EE22ACF1F700D6C63C /* ModuleEventsListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A93ED22ACF1F700D6C63C /* ModuleEventsListener.swift */; };
 		505D0A7F22BD352D00547532 /* ViewControllerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505D0A7E22BD352D00547532 /* ViewControllerEvent.swift */; };
@@ -108,6 +109,7 @@
 		502E0E6421D2FF29004A4F56 /* RxExtensionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxExtensionTestCase.swift; sourceTree = "<group>"; };
 		502E0E6621D2FF9F004A4F56 /* BoolRxExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolRxExtensionTests.swift; sourceTree = "<group>"; };
 		502E0E6821D3A8C5004A4F56 /* RxExtension+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxExtension+String.swift"; sourceTree = "<group>"; };
+		503E60B42377019F00EE01A2 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		504308DD22AEA789008AC2AB /* MockModuleListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModuleListener.swift; sourceTree = "<group>"; };
 		504A93ED22ACF1F700D6C63C /* ModuleEventsListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleEventsListener.swift; sourceTree = "<group>"; };
 		505D0A7E22BD352D00547532 /* ViewControllerEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerEvent.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 			children = (
 				50FDFF8B214E737C00BC5CFD /* MERLin.podspec */,
 				501D6F082130BB4F00114F5A /* MERLin.h */,
+				503E60B42377019F00EE01A2 /* OSLog.swift */,
 				501D6F6E2130BD1200114F5A /* Module.swift */,
 				501D6F6D2130BD1200114F5A /* ModuleContext.swift */,
 				501D6F6C2130BD1100114F5A /* BaseModuleManager.swift */,
@@ -545,6 +548,7 @@
 				501D6F722130BD1200114F5A /* Module.swift in Sources */,
 				501D6FAE2130BD3800114F5A /* EventsListener.swift in Sources */,
 				501D6FAD2130BD3800114F5A /* RxExtension.swift in Sources */,
+				503E60B52377019F00EE01A2 /* OSLog.swift in Sources */,
 				502E0E6121CF9641004A4F56 /* RxCocoa+UICollectionViewFlowLayout.swift in Sources */,
 				50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */,
 				501D6F712130BD1200114F5A /* ModuleContext.swift in Sources */,
@@ -676,7 +680,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanuovaera.MERLin;
+				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TEST";
@@ -847,7 +851,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanuovaera.MERLin;
+				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
@@ -877,7 +881,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanuovaera.MERLin;
+				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";

--- a/MERLin/MERLin/OSLog.swift
+++ b/MERLin/MERLin/OSLog.swift
@@ -1,0 +1,18 @@
+//
+//  OSLog.swift
+//  MERLin
+//
+//  Created by Giuseppe Lanza on 09/11/2019.
+//  Copyright © 2019 Giuseppe Lanza. All rights reserved.
+//
+
+import os.log
+
+extension OSLog {
+    private static var subsystem = "com.merlintech.merlin"
+    
+    static let moduleManager = OSLog(subsystem: subsystem, category: "ModuleManager")
+    static let router = OSLog(subsystem: subsystem, category: "Router")
+    static let listener = OSLog(subsystem: subsystem, category: "EventsListener")
+    static let producer = OSLog(subsystem: subsystem, category: "Producer")
+}

--- a/MERLin/MERLin/Routing/PresentableRoutingStep.swift
+++ b/MERLin/MERLin/Routing/PresentableRoutingStep.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum RoutingStepPresentationMode {
+public enum RoutingStepPresentationMode: CustomStringConvertible {
     case none
     case embed(parentController: UIViewController, containerView: UIView)
     case push(withCloseButton: Bool, onClose: (() -> Void)?)
@@ -22,9 +22,29 @@ public enum RoutingStepPresentationMode {
         case .embed, .modal, .none: return nil
         }
     }
+    
+    public var description: String {
+        switch self {
+        case .none: return "none"
+        case .embed(let parentController, _):
+            return "embed into \(parentController)"
+        case let .push(withCloseButton, onClose):
+            return "push" +
+                (withCloseButton ?
+                    " forcing close button" + (onClose == nil ? "" : ", injecting custom action on close") :
+                    "")
+        case let .modal(modalPresentationStyle):
+            return "modal with style \(modalPresentationStyle)"
+        case let .modalWithNavigation(modalPresentationStyle, withCloseButton, onClose):
+            return "modal with style \(modalPresentationStyle) in navigation bar" +
+                (withCloseButton ?
+                    " forcing close button" + (onClose == nil ? "" : ", injecting custom action on close") :
+                    "")
+        }
+    }
 }
 
-public struct ModuleRoutingStep {
+public struct ModuleRoutingStep: CustomStringConvertible {
     private var wrappedMaker: AnyModuleContextProtocol
     public var routingContext: String { return wrappedMaker.routingContext }
     
@@ -35,9 +55,13 @@ public struct ModuleRoutingStep {
     public init(withMaker maker: AnyModuleContextProtocol) {
         wrappedMaker = maker
     }
+    
+    public var description: String {
+        return "Context: \(wrappedMaker); Flow: \(routingContext)"
+    }
 }
 
-public struct PresentableRoutingStep {
+public struct PresentableRoutingStep: CustomStringConvertible {
     public let step: ModuleRoutingStep
     public let presentationMode: RoutingStepPresentationMode
     public let animated: Bool
@@ -46,5 +70,9 @@ public struct PresentableRoutingStep {
         self.step = step
         self.presentationMode = presentationMode
         self.animated = animated
+    }
+    
+    public var description: String {
+        return "\(step) -|- Presentation mode: \(presentationMode) -|- Animated: \(animated)"
     }
 }

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Giuseppe Lanza. All rights reserved.
 //
 
+import os.log
 import RxSwift
 
 public typealias ViewControllersFactory = ViewControllerBuilding & DeeplinkManaging
@@ -37,7 +38,11 @@ public protocol Router: AnyObject {
      */
     @discardableResult func route(to destination: PresentableRoutingStep) -> UIViewController?
     @discardableResult func route(to viewController: UIViewController, withPresentationMode mode: RoutingStepPresentationMode, animated: Bool) -> UIViewController?
+    
     @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> [UIViewController]?
+    @discardableResult func route(toDeeplink deeplink: String, shouldPush: Bool, userInfo: [String: Any]?) -> [UIViewController]?
+    @discardableResult func route(toDeeplink deeplink: String, traverseAll: Bool, userInfo: [String: Any]?) -> [UIViewController]?
+    @discardableResult func route(toDeeplink deeplink: String, shouldPush: Bool, traverseAll: Bool, userInfo: [String: Any]?) -> [UIViewController]?
     
     func handleShortcutItem(_ item: UIApplicationShortcutItem)
     
@@ -60,6 +65,7 @@ public extension Router {
     @discardableResult func route(to viewController: UIViewController, withPresentationMode mode: RoutingStepPresentationMode, animated: Bool) -> UIViewController? {
         if case let .embed(info) = mode {
             // We can avoid to compute the topController in this case
+            os_log("Embedding %@ in %@", log: .router, type: .debug, viewController, info.parentController)
             return embed(viewController: viewController, embedInfo: info)
         }
         
@@ -68,12 +74,15 @@ public extension Router {
             topController = selectedController
         }
         
+        os_log("Showing %@ with presentation mode %@", log: .router, type: .debug, viewController, mode.description)
+        
         switch mode {
         case let .push(closeButton, onClose):
             if closeButton {
                 viewController.navigationItem.leftBarButtonItem = self.closeButton(for: viewController, onClose: onClose)
             }
             guard let navController = topController as? UINavigationController else {
+                os_log("Could not push %@. Presenting it instead", log: .router, type: .fault, viewController)
                 topController.present(viewController, animated: animated, completion: nil)
                 return viewController
             }
@@ -97,6 +106,7 @@ public extension Router {
     @discardableResult func route(to destination: PresentableRoutingStep) -> UIViewController? {
         guard let viewControllersFactory = viewControllersFactory else { return nil }
         let viewController = viewControllersFactory.viewController(for: destination)
+        os_log("got %@ for routing step: %@", log: .router, type: .debug, viewController, destination.description)
         return route(to: viewController, withPresentationMode: destination.presentationMode, animated: destination.animated)
     }
     
@@ -120,6 +130,7 @@ public extension Router {
     private func closeButton(for viewController: UIViewController, onClose: (() -> Void)?) -> UIBarButtonItem {
         let button = UIBarButtonItem(title: closeButtonString, style: .plain, target: nil, action: nil)
         button.rx.tap.subscribe(onNext: { [unowned viewController] in
+            os_log("%@ dismissed using MERLin close button", log: .router, type: .info, viewController)
             viewController.dismiss(animated: true, completion: onClose)
         }).disposed(by: disposeBag)
         return button
@@ -130,7 +141,19 @@ public extension Router {
 
 public extension Router {
     @discardableResult func route(toDeeplink deeplink: String, userInfo: [String: Any]?) -> [UIViewController]? {
-        return handleDeeplink(deeplink, userInfo: userInfo)
+        return handleDeeplink(deeplink, shouldPush: false, traverseAll: true, userInfo: userInfo)
+    }
+    
+    @discardableResult func route(toDeeplink deeplink: String, shouldPush: Bool, userInfo: [String: Any]?) -> [UIViewController]? {
+        return handleDeeplink(deeplink, shouldPush: shouldPush, traverseAll: true, userInfo: userInfo)
+    }
+    
+    @discardableResult func route(toDeeplink deeplink: String, traverseAll: Bool, userInfo: [String: Any]?) -> [UIViewController]? {
+        return handleDeeplink(deeplink, shouldPush: false, traverseAll: traverseAll, userInfo: userInfo)
+    }
+    
+    @discardableResult func route(toDeeplink deeplink: String, shouldPush: Bool, traverseAll: Bool, userInfo: [String: Any]?) -> [UIViewController]? {
+        return handleDeeplink(deeplink, shouldPush: shouldPush, traverseAll: traverseAll, userInfo: userInfo)
     }
     
     /**
@@ -151,13 +174,21 @@ public extension Router {
      - parameter shouldPush: Determine if the deeplinked viewController should be pushed or presented
      modally in case the "top of the stack" viewController is an UINavigationController. Should push
      also ignores updatable controllers, unless the deeplink is not updatable itself from the current deeplink
+     - parameter traverseAll: Determine if the updatable view controller should be searched in depth
+     in case of nesting of containers in the currently visible view controller. Specifically, in case of a tab bar controller
+     containing for each controller a navigation controller. With this parameter as false the search would stop to the
+     navigation controller, while with true the search will inspect the view controllers contained in the navigation controller also
      */
     @discardableResult
-    func handleDeeplink(_ deeplink: String, from: UIViewController? = nil, shouldPush: Bool = false, traverseAll: Bool = false, userInfo: [String: Any]?) -> [UIViewController]? {
+    private func handleDeeplink(_ deeplink: String, from: UIViewController? = nil, shouldPush: Bool = false, traverseAll: Bool = false, userInfo: [String: Any]?) -> [UIViewController]? {
         guard let viewControllersFactory = viewControllersFactory,
             let controllerClass = viewControllersFactory.viewControllerType(fromDeeplink: deeplink) else {
+            os_log("🔗 Could not find a responder for deeplink %@", log: .router, type: .debug, deeplink)
             return nil
         }
+        
+        os_log("🔗 Found responder for deeplink (%@), searching for a controller of type %@",
+               log: .router, type: .debug, deeplink, String(describing: controllerClass))
         
         // First check on top of the stack
         var currentController = from ?? currentViewController()
@@ -169,12 +200,16 @@ public extension Router {
             if controller.isMember(of: controllerClass) {
                 handled = viewControllersFactory.update(viewController: controller, fromDeeplink: deeplink, userInfo: userInfo)
                 deeplinkedController = controller
+                os_log("🔗 Found controller candidate for deeplink %@: %@ the controller was %@updated",
+                       log: .router, type: .debug, deeplink, controller, handled ? "" : "not ")
             } else if !shouldPush || traverseAll || controller == (currentController as? UITabBarController)?.selectedViewController,
                 let contained = (controller as? UINavigationController)?.viewControllers.last,
                 contained.isMember(of: controllerClass) {
                 // currentController might be a navigation controller (most likely) containing the controller class
                 handled = viewControllersFactory.update(viewController: contained, fromDeeplink: deeplink, userInfo: userInfo)
                 deeplinkedController = contained
+                os_log("🔗 Found controller candidate for deeplink %@: %@ the controller was %@updated",
+                       log: .router, type: .debug, deeplink, contained, handled ? "" : "not ")
             }
             
             if handled {
@@ -187,9 +222,11 @@ public extension Router {
         // we want to fallback on the default present/push logic
         if !handled {
             guard let deeplinkedViewController = viewControllersFactory.viewController(fromDeeplink: deeplink, userInfo: userInfo) else {
+                os_log("🔗 Could not create a controller for the deeplink %@ expected a view controller given that a responder exists.",
+                       log: .router, type: .fault, deeplink)
                 return nil
             }
-            
+            os_log("🔗 Obtained a new viewController for deeplink %@ : %@", log: .router, type: .debug, deeplink, deeplinkedViewController)
             var animated = false
             
             #if !TEST
@@ -202,13 +239,21 @@ public extension Router {
                 let navigationController = currentController as? UINavigationController ??
                 (currentController as? UITabBarController)?.selectedViewController as? UINavigationController {
                 navigationController.pushViewController(deeplinkedViewController, animated: animated)
+                
+                os_log("🔗 Pushed view controller %@ for deeplink %@", log: .router, type: .debug, deeplinkedViewController, deeplink)
             } else {
+                if shouldPush {
+                    os_log("🔗 Could not push as the current view controller (%@) is not a navigation controller and does not contain a navigation controller",
+                           log: .router, type: .debug, currentController)
+                }
                 let navigationController = UINavigationController(rootViewController: deeplinkedViewController)
                 
                 currentController.present(navigationController, animated: animated, completion: nil)
                 
                 deeplinkedViewController.navigationItem.leftBarButtonItem = closeButton(for: deeplinkedViewController, onClose: nil)
                 currentController = navigationController
+                os_log("🔗 Presenting %@ modally in a new navigation controller for deeplink %@",
+                       log: .router, type: .debug, deeplinkedViewController, deeplink)
             }
             
             deeplinkedController = deeplinkedViewController
@@ -222,11 +267,12 @@ public extension Router {
     /// would cause product array to match the first part, and to have `/pdp/112233` unmatched
     /// a new deeplink is then generated in this method to be theBay://pdp/112233 and then pushed
     @discardableResult
-    func pushUnmatched(fromDeeplink deeplink: String, from: UIViewController?, userInfo: [String: Any]?) -> [UIViewController]? {
+    private func pushUnmatched(fromDeeplink deeplink: String, from: UIViewController?, userInfo: [String: Any]?) -> [UIViewController]? {
         guard let newDeeplink = viewControllersFactory?.unmatchedDeeplinkRemainder(fromDeeplink: deeplink) else {
             return nil
         }
-        
+        os_log("🔗 Deeplink %@ was routed and has a remainder formed by a contiguous portion of the url not consumed by the responder: %@",
+               log: .router, type: .debug, deeplink, newDeeplink)
         return handleDeeplink(newDeeplink, from: from, shouldPush: true, traverseAll: false, userInfo: userInfo)
     }
 }

--- a/MERLin/MERLinTests/Tests/Router/RouterTests.swift
+++ b/MERLin/MERLinTests/Tests/Router/RouterTests.swift
@@ -166,7 +166,7 @@ class RouterTests: XCTestCase {
     
     func testItCanPushFromCurrentContext() {
         let deeplink = "test://mock/"
-        let controllers = router.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
+        let controllers = router.route(toDeeplink: deeplink, shouldPush: true, userInfo: nil)
         
         XCTAssertEqual((router.topViewController as? UINavigationController)?.viewControllers.count, 2)
         XCTAssertEqual(controllers?.first, (router.topViewController as? UINavigationController)?.viewControllers.last)
@@ -186,7 +186,7 @@ class RouterTests: XCTestCase {
             tabbarController.selectedIndex = index
             XCTAssertEqual((tabbarController.selectedViewController as? UINavigationController)?.viewControllers.count, 1)
             
-            let controllers = tabBarRouter.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
+            let controllers = tabBarRouter.route(toDeeplink: deeplink, shouldPush: true, userInfo: nil)
             
             XCTAssertEqual(controllers?.first, (tabbarController.selectedViewController as? UINavigationController)?.viewControllers.last)
             XCTAssertEqual((tabbarController.selectedViewController as? UINavigationController)?.viewControllers.count, 2)
@@ -197,7 +197,7 @@ class RouterTests: XCTestCase {
         let (tabBarRouter, _, _) = setupTabBarRootViewController()
         let deeplink = "test://mock/product/1234"
         
-        let controllers = tabBarRouter.handleDeeplink(deeplink, shouldPush: true, userInfo: nil)
+        let controllers = tabBarRouter.route(toDeeplink: deeplink, shouldPush: true, userInfo: nil)
         
         guard let tabbarController = tabBarRouter.topViewController as? UITabBarController else {
             XCTFail("At this point this controller should be a tab bar")


### PR DESCRIPTION
Added logging via os_log to MERLin.

the logs will look like `[ModuleManager] 🖼 Building module for step: Context: MERLin.ModuleContext; Flow: default -|- Presentation mode: push -|- Animated: true`

So it will be particularly easy to filter in the Xcode debugger for certain events.
You can filter by [ModuleManager] or by emoticon to filter the whole flow between router and module manager for deeplinks, for example.