### PR TITLE
Customizing ViewController before presenting it

### DIFF
--- a/MERLin/MERLin/Routing/PresentableRoutingStep.swift
+++ b/MERLin/MERLin/Routing/PresentableRoutingStep.swift
@@ -66,10 +66,19 @@ public struct PresentableRoutingStep: CustomStringConvertible {
     public let presentationMode: RoutingStepPresentationMode
     public let animated: Bool
     
-    public init(withStep step: ModuleRoutingStep, presentationMode: RoutingStepPresentationMode, animated: Bool = true) {
+    /// This closure will be invoked right before the viewController associated to the step will be pushed/presented.
+    /// This closure should be used for further customization of the presentation style like custom animators.
+    ///
+    /// The viewController passed to this closure will be the ViewController after the presentation mode customization
+    /// but before this is associated to a container, meaning that it will not have any parent, not a navigationController
+    /// or a tabBarController.
+    public let beforePresenting: ((UIViewController) -> Void)?
+    
+    public init(withStep step: ModuleRoutingStep, presentationMode: RoutingStepPresentationMode, animated: Bool = true, beforePresenting: ((UIViewController) -> Void)? = nil) {
         self.step = step
         self.presentationMode = presentationMode
         self.animated = animated
+        self.beforePresenting = beforePresenting
     }
     
     public var description: String {

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -107,6 +107,7 @@ public extension Router {
         guard let viewControllersFactory = viewControllersFactory else { return nil }
         let viewController = viewControllersFactory.viewController(for: destination)
         os_log("got %@ for routing step: %@", log: .router, type: .debug, viewController, destination.description)
+        destination.beforePresenting?(viewController)
         return route(to: viewController, withPresentationMode: destination.presentationMode, animated: destination.animated)
     }
     


### PR DESCRIPTION
This PR add a way to customise a viewController associated to a step before this is presented on screen. Customization to ViewControlelrs before were possible only after presentation via the return of the route function. This is too late for customisation like custom animators.