### PR TITLE
Add viewController to update method in deeplink

### DIFF
--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "2.2.1"
+    s.version = "3.0.0"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source = {
         :git => "https://github.com/gringoireDM/MERLin.git",
-        :tag => "v2.2.1"
+        :tag => "v3.0.0"
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.3.2'

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -672,9 +672,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TEST";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -843,9 +845,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -873,9 +877,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -199,20 +199,12 @@
 		501D6F7D2130BD3600114F5A /* Deeplinking */ = {
 			isa = PBXGroup;
 			children = (
+				501D6F812130BD3600114F5A /* DeeplinkMatcher.h */,
+				501D6F802130BD3600114F5A /* DeeplinkMatcher.m */,
 				501D6F7E2130BD3600114F5A /* Deeplink.swift */,
-				501D6F7F2130BD3600114F5A /* Extensions */,
 				501D6F822130BD3600114F5A /* DeeplinkManaging.swift */,
 			);
 			path = Deeplinking;
-			sourceTree = "<group>";
-		};
-		501D6F7F2130BD3600114F5A /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				501D6F812130BD3600114F5A /* DeeplinkMatcher.h */,
-				501D6F802130BD3600114F5A /* DeeplinkMatcher.m */,
-			);
-			path = Extensions;
 			sourceTree = "<group>";
 		};
 		501D6F862130BD3700114F5A /* Routing */ = {

--- a/MERLin/MERLin/BaseModuleManager.swift
+++ b/MERLin/MERLin/BaseModuleManager.swift
@@ -114,7 +114,7 @@ extension BaseModuleManager: DeeplinkManaging {
     
     @discardableResult public func update(viewController: UIViewController, fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
         guard let module = self.module(for: viewController) as? DeeplinkContextUpdatable else { return false }
-        return module.updateContext(fromDeeplink: deeplink, userInfo: userInfo)
+        return module.updateContext(for: viewController, fromDeeplink: deeplink, userInfo: userInfo)
     }
     
     public func viewController(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> UIViewController? {
@@ -137,7 +137,7 @@ extension BaseModuleManager: ViewControllerBuilding {
         
         os_log("🖼 Built new module of type %@ with its viewController: %@", log: .moduleManager, type: .debug,
                String(describing: type(of: module)), String(describing: type(of: controller)))
-
+        
         module.newViewControllers.skip(1)
             .observeOn(SerialDispatchQueueScheduler(qos: .userInitiated))
             .subscribe(onNext: { [weak self, weak module] newVC in

--- a/MERLin/MERLin/BaseModuleManager.swift
+++ b/MERLin/MERLin/BaseModuleManager.swift
@@ -21,7 +21,7 @@ class ModuleWrapper: Hashable {
     }
     
     func hash(into hasher: inout Hasher) {
-        hasher.combine(module.hash)
+        hasher.combine(Unmanaged.passUnretained(module as AnyObject).toOpaque())
     }
 }
 

--- a/MERLin/MERLin/Deeplinking/Deeplink.swift
+++ b/MERLin/MERLin/Deeplinking/Deeplink.swift
@@ -16,29 +16,6 @@ public enum DeeplinkMatchingPriority: Int {
     case veryHigh
 }
 
-/**
- Make a Module subclass conforming this protocol to make that module
- automatically deeplinkable. The principle behind this automatic implementation
- is that to make a module deeplinkable should be simple enough and should not
- require additional code, and the list of available deeplinkable modules should
- reflect (and expand) accordingly to the modules built in the app.
- The removal or the addition of a Deeplinkable module **must** not affect the
- rest of the app. The list of available deeplinkable modules is built in runtime
- so that no maintenance is needed once the deeplink engin is built to be agnostic
- respect the modules that are going to be deeplinked. In this way, also god
- deeplink managers are avoided, and nobody knows how to build a module out of a
- deeplink, if not the module itself.
- */
-@objc public protocol DeeplinkResponder: NSObjectProtocol {
-    /// The schemas that can be used for the deeplink. They will be used in the regex
-    /// chained as **or** matches. `(schema1|schema2):\/\/....`
-    static var deeplinkSchemaNames: [String] { get set }
-    
-    /// The regex to parse the deeplink and decide if the module implementing Deeplinkable
-    /// can handle the deeplink.
-    @objc static func deeplinkRegexes() -> [NSRegularExpression]?
-}
-
 public protocol Deeplinkable: DeeplinkResponder {
     static var priority: DeeplinkMatchingPriority { get }
     
@@ -81,7 +58,7 @@ public extension Deeplinkable {
     
     static func defaultRemainderDeeplink(fromDeeplink deeplink: String) -> String? {
         let optionalSchema = deeplinkSchemaNames.first {
-            return deeplink.hasPrefix($0)
+            deeplink.hasPrefix($0)
         }
         
         guard let schema = optionalSchema,
@@ -94,7 +71,7 @@ public extension Deeplinkable {
             .map(String.init)
             .joined(separator: "/")
         
-        guard remainder.count > 0 && remainder != "/" else { return nil }
+        guard remainder.count > 0, remainder != "/" else { return nil }
         
         let resultingDeeplink = "\(schema)://\(remainder)".replacingOccurrences(of: "///", with: "//")
         return resultingDeeplink

--- a/MERLin/MERLin/Deeplinking/DeeplinkMatcher.h
+++ b/MERLin/MERLin/Deeplinking/DeeplinkMatcher.h
@@ -25,17 +25,18 @@ deeplink, if not the module itself.
 
 /// The schemas that can be used for the deeplink. They will be used in the regex
 /// chained as **or** matches. `(schema1|schema2):\/\/....`
-@property (class, nonatomic, retain) NSArray<NSString *> *deeplinkSchemaNames;
+@property (class, nonatomic, retain) NSArray<NSString *> * _Nonnull deeplinkSchemaNames;
 
 /// The regex to parse the deeplink and decide if the module implementing Deeplinkable
 /// can handle the deeplink.
-+ (NSArray<NSRegularExpression *> *) deeplinkRegexes;
++ (NSArray<NSRegularExpression *> * _Nonnull) deeplinkRegexes;
 
 @end
 
+
 @interface DeeplinkMatcher : NSObject
 
-+ (NSMutableDictionary *) availableDeeplinkHandlers;
++ (NSMutableDictionary<NSRegularExpression *, Class> * _Nonnull) availableDeeplinkHandlers;
 
 @end
 

--- a/MERLin/MERLin/Deeplinking/DeeplinkMatcher.m
+++ b/MERLin/MERLin/Deeplinking/DeeplinkMatcher.m
@@ -12,9 +12,9 @@
 
 @implementation DeeplinkMatcher
 
-static NSMutableDictionary * _availableDeeplinkHandlers;
+static NSMutableDictionary<NSRegularExpression *, Class> * _availableDeeplinkHandlers;
 
-+ (NSMutableDictionary *) availableDeeplinkHandlers {
++ (NSMutableDictionary<NSRegularExpression *, Class>  *) availableDeeplinkHandlers {
     return _availableDeeplinkHandlers;
 }
 

--- a/MERLin/MERLin/Deeplinking/Extensions/DeeplinkMatcher.h
+++ b/MERLin/MERLin/Deeplinking/Extensions/DeeplinkMatcher.h
@@ -8,6 +8,31 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+Make a Module subclass conforming this protocol to make that module
+automatically deeplinkable. The principle behind this automatic implementation
+is that to make a module deeplinkable should be simple enough and should not
+require additional code, and the list of available deeplinkable modules should
+reflect (and expand) accordingly to the modules built in the app.
+The removal or the addition of a Deeplinkable module **must** not affect the
+rest of the app. The list of available deeplinkable modules is built in runtime
+so that no maintenance is needed once the deeplink engin is built to be agnostic
+respect the modules that are going to be deeplinked. In this way, also god
+deeplink managers are avoided, and nobody knows how to build a module out of a
+deeplink, if not the module itself.
+*/
+@protocol DeeplinkResponder
+
+/// The schemas that can be used for the deeplink. They will be used in the regex
+/// chained as **or** matches. `(schema1|schema2):\/\/....`
+@property (class, nonatomic, retain) NSArray<NSString *> *deeplinkSchemaNames;
+
+/// The regex to parse the deeplink and decide if the module implementing Deeplinkable
+/// can handle the deeplink.
++ (NSArray<NSRegularExpression *> *) deeplinkRegexes;
+
+@end
+
 @interface DeeplinkMatcher : NSObject
 
 + (NSMutableDictionary *) availableDeeplinkHandlers;

--- a/MERLin/MERLin/Deeplinking/Extensions/DeeplinkMatcher.m
+++ b/MERLin/MERLin/Deeplinking/Extensions/DeeplinkMatcher.m
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <MERLin/DeeplinkMatcher.h>
-#import <MERLin/MERLin-Swift.h>
+#import <Objc/Runtime.h>
 
 @implementation DeeplinkMatcher
 

--- a/MERLin/MERLin/Info.plist
+++ b/MERLin/MERLin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MERLin/MERLin/Module.swift
+++ b/MERLin/MERLin/Module.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-public protocol AnyModule: AnyObject, NSObjectProtocol {
+public protocol AnyModule: AnyObject {
     var routingContext: String { get }
     
     func unmanagedRootViewController() -> UIViewController

--- a/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
@@ -39,7 +39,7 @@ class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
         return URL(string: "test://mock")
     }
     
-    static func deeplinkRegexes() -> [NSRegularExpression]? {
+    static func deeplinkRegexes() -> [NSRegularExpression] {
         let testRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
         let anotherTestRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
         
@@ -75,7 +75,7 @@ class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, DeeplinkConte
         return URL(string: "test://mock")
     }
     
-    static func deeplinkRegexes() -> [NSRegularExpression]? {
+    static func deeplinkRegexes() -> [NSRegularExpression] {
         let testRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
         let testProductRegEx = try! NSRegularExpression(pattern: "\\btest\\:\\/\\/.*product\\/?([0-9]+)", options: .caseInsensitive)
         let anotherTestRegEx = try! NSRegularExpression(pattern: "\\banotherTest\\:\\/\\/mock\\/?([0-9]*)", options: .caseInsensitive)
@@ -84,7 +84,7 @@ class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, DeeplinkConte
         return [testRegEx, testProductRegEx, anotherTestRegEx, anotherTestProductRegEx]
     }
     
-    func updateContext(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
+    func updateContext(for controller: UIViewController, fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
         return !deeplink.contains("mock")
     }
 }

--- a/MERLin/MERLinTests/Tests/Modules/DeeplinkableTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/DeeplinkableTests.swift
@@ -12,17 +12,17 @@ import XCTest
 class DeeplinkableTests: XCTestCase {
     func testThatMockIsIncludedInAvailableDeeplinkHandlers() {
         let mockType = DeeplinkMatcher.typedAvailableDeeplinkHandlers.values.filter { (type) -> Bool in
-            return type == MockDeeplinkable.self
+            type == MockDeeplinkable.self
         }
-        XCTAssertEqual(mockType.count, MockDeeplinkable.deeplinkRegexes()!.count)
+        XCTAssertEqual(mockType.count, MockDeeplinkable.deeplinkRegexes().count)
     }
     
     func testThatMockRegularExpressionsAreInAvailableDeeplinkHandlers() {
         let regExp = DeeplinkMatcher.typedAvailableDeeplinkHandlers.keys.filter { (regEx) -> Bool in
-            return DeeplinkMatcher.typedAvailableDeeplinkHandlers[regEx] == MockDeeplinkable.self
+            DeeplinkMatcher.typedAvailableDeeplinkHandlers[regEx] == MockDeeplinkable.self
         }
         
-        XCTAssertEqual(Set(regExp), Set(MockDeeplinkable.deeplinkRegexes()!))
+        XCTAssertEqual(Set(regExp), Set(MockDeeplinkable.deeplinkRegexes()))
     }
     
     func testDeeplinkRemainder() {

--- a/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
@@ -48,7 +48,7 @@ class ModuleManagerTests: XCTestCase {
         
         autoreleasepool { viewController = nil }
         XCTAssertEqual(moduleManager.moduleRetainer.count, 1)
-        XCTAssert(moduleManager.module(for: newVC)?.isEqual(module) == true)
+        XCTAssert(moduleManager.module(for: newVC) === module)
     }
     
     func testItCanAddEventsListeners() {

--- a/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
@@ -44,6 +44,7 @@ class ModuleManagerTests: XCTestCase {
         
         XCTAssertEqual(moduleManager.livingModules().count, 1)
         XCTAssertNotNil(moduleManager.module(for: viewController!))
+        XCTAssertEqual(moduleManager.moduleRetainer.count, 2)
         
         autoreleasepool { viewController = nil }
         XCTAssertEqual(moduleManager.moduleRetainer.count, 1)

--- a/MERLinSample/MERLinSample.xcodeproj/project.pbxproj
+++ b/MERLinSample/MERLinSample.xcodeproj/project.pbxproj
@@ -172,7 +172,6 @@
 				CE633876309C2A9DF242CB03 /* Pods-MERLinTargets-RestaurantsListModule.debug.xcconfig */,
 				9D9184FCD63937B58BE4184D /* Pods-MERLinTargets-RestaurantsListModule.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -447,15 +446,15 @@
 				TargetAttributes = {
 					50B1187C213C19F8008928AF = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 					50B1189F213C30BF008928AF = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 					50B118D8213C4374008928AF = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 				};
 			};
@@ -804,7 +803,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 108A246449797A6544E993D8 /* Pods-MERLinTargets-MERLinSample.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MERLinSample/Info.plist;
@@ -814,7 +812,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlin.MERLinSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -823,7 +821,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 195E46F95D9B617275F3E14B /* Pods-MERLinTargets-MERLinSample.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MERLinSample/Info.plist;
@@ -833,7 +830,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlin.MERLinSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -861,7 +858,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -890,7 +887,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlin.RestaurantsListModule;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -920,7 +917,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -949,7 +946,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlin.RestaurantDetailModule;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/MERLinSample/Podfile.lock
+++ b/MERLinSample/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - EnumKit (1.0.0)
   - LNZWeakCollection (1.3.2)
-  - MERLin (2.2.0):
+  - MERLin (2.2.1):
     - LNZWeakCollection (~> 1.3.2)
     - RxEnumKit (~> 1.0.1)
   - RxCocoa (5.0.0):
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   EnumKit: 8ee9561b3a7d2696d2e5aa37d5b9eba5f7139783
   LNZWeakCollection: 0211da4f8778cb35d1b9fa788a3cb395e26a0226
-  MERLin: 8e2343908e2ca0cc89d5b6759fad9f20a18d67de
+  MERLin: 61c66a66e94268a5bc968de28b03e1e96c3054f2
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
   RxEnumKit: f51b6ae14fdae994a66b8a39d166116b8e0befc1
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18

--- a/MERLinSample/RestaurantDetailModule/RestaurantDetailModule+Deeplink.swift
+++ b/MERLinSample/RestaurantDetailModule/RestaurantDetailModule+Deeplink.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-extension RestaurantDetailModule: DeeplinkContextUpdatable {
+extension RestaurantDetailModule: Deeplinkable {
     public static var deeplinkSchemaNames: [String] = ["rest"]
-    public static func deeplinkRegexes() -> [NSRegularExpression]? {
-        guard deeplinkSchemaNames.count > 0 else { return nil }
+    public static func deeplinkRegexes() -> [NSRegularExpression] {
+        guard deeplinkSchemaNames.count > 0 else { return [] }
         
         var regexString = "\\b("
         regexString += deeplinkSchemaNames.joined(separator: "|") + ")\\:\\/\\/"
@@ -31,7 +31,10 @@ extension RestaurantDetailModule: DeeplinkContextUpdatable {
     }
     
     private static func context(fromDeeplink deeplink: String) -> RestaurantDetailBuildContext? {
-        guard let match = deeplinkRegexes()?.compactMap({ $0.firstMatch(in: deeplink, range: NSRange(location: 0, length: deeplink.count)) }).first,
+        guard let match = deeplinkRegexes()
+            .compactMap({
+                $0.firstMatch(in: deeplink, range: NSRange(location: 0, length: deeplink.count))
+            }).first,
             let idRange = Range(match.range(at: match.numberOfRanges - 1), in: deeplink) else { return nil }
         
         let id = String(deeplink[idRange])
@@ -43,10 +46,6 @@ extension RestaurantDetailModule: DeeplinkContextUpdatable {
         
         let module = RestaurantDetailModule(usingContext: context)
         return (module, module.prepareRootViewController())
-    }
-    
-    public func updateContext(fromDeeplink deeplink: String, userInfo: [String: Any]?) -> Bool {
-        return false // don't want to replace the current restaurant on screen if any.
     }
 }
 

--- a/MERLinSample/RestaurantsListModule/RestaurantsListModule.swift
+++ b/MERLinSample/RestaurantsListModule/RestaurantsListModule.swift
@@ -18,7 +18,7 @@ extension UIStoryboard {
     }
 }
 
-public class RestaurantsListModule: NSObject, ModuleProtocol, EventsProducer {
+public class RestaurantsListModule: ModuleProtocol, EventsProducer {
     public var context: ModuleContext
     
     public var events: Observable<RestaurantsListEvent> { return _events }
@@ -34,6 +34,5 @@ public class RestaurantsListModule: NSObject, ModuleProtocol, EventsProducer {
     
     public required init(usingContext buildContext: ModuleContext) {
         context = buildContext
-        super.init()
     }
 }


### PR DESCRIPTION
This PR also removes inverse dependency of objective-c code to swift. This is a fundamental step to support Swift package manager: Objective-c code must be isolated and autonomous.

From this PR, Modules are no longer required to be NSObjects if they are not Deeplinkable, but they still need to be a class.

Deeplinkable still requires NSObject constraint