### PR TITLE
allowing deeper customization of the close button for modals

### DIFF
--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -447,28 +447,11 @@
 			files = (
 			);
 			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/EnumKit/EnumKit.framework",
-				"${BUILT_PRODUCTS_DIR}/LNZWeakCollection/LNZWeakCollection.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
-				"${BUILT_PRODUCTS_DIR}/RxEnumKit/RxEnumKit.framework",
-				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
-				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/RxTest/RxTest.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/EnumKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LNZWeakCollection.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxEnumKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxTest.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MERLin/MERLin/Routing/PresentableRoutingStep.swift
+++ b/MERLin/MERLin/Routing/PresentableRoutingStep.swift
@@ -13,6 +13,14 @@ public enum CloseButtonType: CustomStringConvertible {
     case title(String, onClose: (() -> Void)?)
     case image(UIImage, onClose: (() -> Void)?)
     
+    var onCloseAction: (() -> Void)? {
+        switch self {
+        case .none: return nil
+        case let .title(_, onClose),
+             let .image(_, onClose): return onClose
+        }
+    }
+    
     public var description: String {
         switch self {
         case .none: return "no close button"

--- a/MERLin/MERLin/Routing/PresentableRoutingStep.swift
+++ b/MERLin/MERLin/Routing/PresentableRoutingStep.swift
@@ -8,17 +8,33 @@
 
 import Foundation
 
+public enum CloseButtonType: CustomStringConvertible {
+    case none
+    case title(String, onClose: (() -> Void)?)
+    case image(UIImage, onClose: (() -> Void)?)
+    
+    public var description: String {
+        switch self {
+        case .none: return "no close button"
+        case let .title(title, onClose):
+            return "close button with title \"\(title)\"" + (onClose == nil ? "" : ", injecting custom action on close")
+        case let .image(_, onClose):
+            return "close button with image" + (onClose == nil ? "" : ", injecting custom action on close")
+        }
+    }
+}
+
 public enum RoutingStepPresentationMode: CustomStringConvertible {
     case none
     case embed(parentController: UIViewController, containerView: UIView)
-    case push(withCloseButton: Bool, onClose: (() -> Void)?)
+    case push(withCloseButton: CloseButtonType)
     case modal(modalPresentationStyle: UIModalPresentationStyle)
-    case modalWithNavigation(modalPresentationStyle: UIModalPresentationStyle, withCloseButton: Bool, onClose: (() -> Void)?)
+    case modalWithNavigation(modalPresentationStyle: UIModalPresentationStyle, withCloseButton: CloseButtonType)
     
-    public func override(withCloseButton closeButton: Bool, onClose: (() -> Void)?) -> RoutingStepPresentationMode? {
+    public func override(withCloseButton closeButton: CloseButtonType) -> RoutingStepPresentationMode? {
         switch self {
-        case .push: return .push(withCloseButton: closeButton, onClose: onClose)
-        case let .modalWithNavigation(style, _, _): return .modalWithNavigation(modalPresentationStyle: style, withCloseButton: closeButton, onClose: onClose)
+        case .push: return .push(withCloseButton: closeButton)
+        case let .modalWithNavigation(style, _): return .modalWithNavigation(modalPresentationStyle: style, withCloseButton: closeButton)
         case .embed, .modal, .none: return nil
         }
     }
@@ -28,18 +44,12 @@ public enum RoutingStepPresentationMode: CustomStringConvertible {
         case .none: return "none"
         case .embed(let parentController, _):
             return "embed into \(parentController)"
-        case let .push(withCloseButton, onClose):
-            return "push" +
-                (withCloseButton ?
-                    " forcing close button" + (onClose == nil ? "" : ", injecting custom action on close") :
-                    "")
+        case let .push(closeButtonType):
+            return "push with " + closeButtonType.description
         case let .modal(modalPresentationStyle):
             return "modal with style \(modalPresentationStyle)"
-        case let .modalWithNavigation(modalPresentationStyle, withCloseButton, onClose):
-            return "modal with style \(modalPresentationStyle) in navigation bar" +
-                (withCloseButton ?
-                    " forcing close button" + (onClose == nil ? "" : ", injecting custom action on close") :
-                    "")
+        case let .modalWithNavigation(modalPresentationStyle, closeButtonType):
+            return "modal with style \(modalPresentationStyle) in navigation bar and " + closeButtonType.description
         }
     }
 }

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -44,7 +44,7 @@ public protocol Router: AnyObject {
     var topViewController: UIViewController { get }
     var disposeBag: DisposeBag { get }
     
-    var closeButtonString: String { get }
+    var defaultCloseButtonType: CloseButtonType { get }
     /**
      This method has the duty to return the right rootViewController depending on launching options. If there is a deeplink,
      this method should catch it and adjust the rootviewcontroller stack accordingly.
@@ -75,7 +75,8 @@ public protocol Router: AnyObject {
 // MARK: Route to...
 
 public extension Router {
-    var closeButtonString: String { return "Close" }
+    var defaultCloseButtonType: CloseButtonType { return .title("Close", onClose: nil) }
+    
     internal func currentViewController() -> UIViewController {
         var currentController = topViewController
         while let presented = currentController.presentedViewController {
@@ -99,10 +100,8 @@ public extension Router {
         os_log("Showing %@ with presentation mode %@", log: .router, type: .debug, viewController, mode.description)
         
         switch mode {
-        case let .push(closeButton, onClose):
-            if closeButton {
-                viewController.navigationItem.leftBarButtonItem = self.closeButton(for: viewController, onClose: onClose)
-            }
+        case let .push(closeButtonType):
+            viewController.navigationItem.leftBarButtonItem = closeButton(for: viewController, closeButtonType: closeButtonType)
             guard let navController = topController as? UINavigationController else {
                 os_log("Could not push %@. Presenting it instead", log: .router, type: .fault, viewController)
                 topController.present(viewController, animated: animated, completion: nil)
@@ -112,11 +111,9 @@ public extension Router {
         case let .modal(style):
             viewController.modalPresentationStyle = style
             topController.present(viewController, animated: animated, completion: nil)
-        case let .modalWithNavigation(style, closeButton, onClose):
+        case let .modalWithNavigation(style, closeButtonType):
             let navigationController = UINavigationController(rootViewController: viewController)
-            if closeButton {
-                viewController.navigationItem.leftBarButtonItem = self.closeButton(for: viewController, onClose: onClose)
-            }
+            viewController.navigationItem.leftBarButtonItem = closeButton(for: viewController, closeButtonType: closeButtonType)
             navigationController.modalPresentationStyle = style
             topController.present(navigationController, animated: animated, completion: nil)
         case .embed, .none: return viewController
@@ -150,12 +147,24 @@ public extension Router {
         return viewController
     }
     
-    internal func closeButton(for viewController: UIViewController, onClose: (() -> Void)?) -> UIBarButtonItem {
-        let button = UIBarButtonItem(title: closeButtonString, style: .plain, target: nil, action: nil)
+    internal func closeButton(for viewController: UIViewController, closeButtonType: CloseButtonType) -> UIBarButtonItem? {
+        let button: UIBarButtonItem
+        let onCloseAction: (() -> Void)?
+        switch closeButtonType {
+        case .none: return nil
+        case let .title(title, onClose):
+            button = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
+            onCloseAction = onClose
+        case let .image(image, onClose):
+            button = UIBarButtonItem(image: image, style: .plain, target: nil, action: nil)
+            onCloseAction = onClose
+        }
+        
         button.rx.tap.subscribe(onNext: { [unowned viewController] in
             os_log("%@ dismissed using MERLin close button", log: .router, type: .info, viewController)
-            viewController.dismiss(animated: true, completion: onClose)
+            viewController.dismiss(animated: true, completion: onCloseAction)
         }).disposed(by: disposeBag)
+        
         return button
     }
 }
@@ -297,7 +306,8 @@ public extension Router {
                 
                 currentController.present(navigationController, animated: animated, completion: nil)
                 
-                deeplinkedViewController.navigationItem.leftBarButtonItem = closeButton(for: deeplinkedViewController, onClose: nil)
+                deeplinkedViewController.navigationItem.leftBarButtonItem = closeButton(for: deeplinkedViewController,
+                                                                                        closeButtonType: defaultCloseButtonType)
                 currentController = navigationController
                 os_log("🔗 Presenting %@ modally in a new navigation controller for deeplink %@",
                        log: .router, type: .debug, deeplinkedViewController, deeplink)

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -149,20 +149,17 @@ public extension Router {
     
     internal func closeButton(for viewController: UIViewController, closeButtonType: CloseButtonType) -> UIBarButtonItem? {
         let button: UIBarButtonItem
-        let onCloseAction: (() -> Void)?
         switch closeButtonType {
         case .none: return nil
-        case let .title(title, onClose):
+        case let .title(title, _):
             button = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
-            onCloseAction = onClose
-        case let .image(image, onClose):
+        case let .image(image, _):
             button = UIBarButtonItem(image: image, style: .plain, target: nil, action: nil)
-            onCloseAction = onClose
         }
         
         button.rx.tap.subscribe(onNext: { [unowned viewController] in
             os_log("%@ dismissed using MERLin close button", log: .router, type: .info, viewController)
-            viewController.dismiss(animated: true, completion: onCloseAction)
+            viewController.dismiss(animated: true, completion: closeButtonType.onCloseAction)
         }).disposed(by: disposeBag)
         
         return button

--- a/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
+++ b/MERLin/MERLinTests/Mocks/MockDeeplinkableModule.swift
@@ -45,6 +45,10 @@ class MockDeeplinkable: NSObject, ModuleProtocol, Deeplinkable {
         
         return [testRegEx, anotherTestRegEx]
     }
+    
+    func canPush(viewController: UIViewController, forDeeplink deeplink: String) -> Bool {
+        return !deeplink.hasSuffix("noPush")
+    }
 }
 
 class LowPriorityMockDeeplinkableModule: NSObject, ModuleProtocol, DeeplinkContextUpdatable {

--- a/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
+++ b/MERLin/MERLinTests/Tests/Modules/ModuleManagerTests.swift
@@ -24,7 +24,7 @@ class ModuleManagerTests: XCTestCase {
     }
     
     func mockStep() -> PresentableRoutingStep {
-        return PresentableRoutingStep(withStep: .mock(), presentationMode: .push(withCloseButton: false, onClose: nil))
+        return PresentableRoutingStep(withStep: .mock(), presentationMode: .push(withCloseButton: .none))
     }
     
     func testThatItCanRetainModules() {

--- a/MERLin/MERLinTests/Tests/Router/RouterTests.swift
+++ b/MERLin/MERLinTests/Tests/Router/RouterTests.swift
@@ -58,10 +58,22 @@ class RouterTests: XCTestCase {
         XCTAssertNil(root.viewControllers.last?.navigationItem.leftBarButtonItem)
     }
     
-    func testRoutToPushWithCloseButton() {
+    func testRouteToPushWithCloseButton() {
         let step = PresentableRoutingStep(
             withStep: .mock(),
             presentationMode: .push(withCloseButton: .title("Close", onClose: nil)),
+            animated: false
+        )
+        let expected = router.route(to: step)
+        XCTAssertNotNil(expected)
+        XCTAssertEqual(root.viewControllers.last, expected)
+        XCTAssertNotNil(root.viewControllers.last?.navigationItem.leftBarButtonItem)
+    }
+    
+    func testRouteToPushWithCloseButtonImage() {
+        let step = PresentableRoutingStep(
+            withStep: .mock(),
+            presentationMode: .push(withCloseButton: .image(UIImage(), onClose: nil)),
             animated: false
         )
         let expected = router.route(to: step)
@@ -114,6 +126,20 @@ class RouterTests: XCTestCase {
             withStep: .mock(),
             presentationMode: .modalWithNavigation(modalPresentationStyle: .fullScreen,
                                                    withCloseButton: .title("Close", onClose: nil)),
+            animated: false
+        )
+        let expected = router.route(to: step)
+        XCTAssertNotNil(expected)
+        XCTAssert(root.presentedViewController is UINavigationController)
+        XCTAssertEqual(root.presentedViewController?.children.first, expected)
+        XCTAssertNotNil(root.presentedViewController?.children.first?.navigationItem.leftBarButtonItem)
+    }
+    
+    func testRouteToModalWithNavigationWithCloseButtonImage() {
+        let step = PresentableRoutingStep(
+            withStep: .mock(),
+            presentationMode: .modalWithNavigation(modalPresentationStyle: .fullScreen,
+                                                   withCloseButton: .image(UIImage(), onClose: nil)),
             animated: false
         )
         let expected = router.route(to: step)
@@ -242,6 +268,34 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(controllers.first, (router.topViewController as? UINavigationController)?.viewControllers.last)
     }
     
+    func testItCanRejectPushAndFallbackOnModal() {
+        router.topViewController = UIViewController()
+        let deeplink = "test://mock/"
+        let controllers = router.route(
+            toDeeplink: deeplink,
+            behaviour: DeeplinkBehaviour(presentationStyle: .pushIfPossible,
+                                         updatableSearchPreference: .justInCurrentContext,
+                                         shouldFollowRemainder: false),
+            userInfo: nil
+        )
+        
+        XCTAssertEqual((router.topViewController.presentedViewController as? UINavigationController)?.viewControllers.last, controllers.first)
+    }
+    
+    func testItCanFailPushForMissingNavigationController() {
+        let deeplink = "test://mock/noPush"
+        let controllers = router.route(
+            toDeeplink: deeplink,
+            behaviour: DeeplinkBehaviour(presentationStyle: .pushIfPossible,
+                                         updatableSearchPreference: .justInCurrentContext,
+                                         shouldFollowRemainder: false),
+            userInfo: nil
+        )
+        
+        XCTAssertEqual((router.topViewController as? UINavigationController)?.viewControllers.count, 1)
+        XCTAssertEqual((router.topViewController.presentedViewController as? UINavigationController)?.viewControllers.last, controllers.first)
+    }
+    
     func testItCanPushFromCurrentContextInTabBarViewController() {
         let (tabBarRouter, _, _, _) = setupTabBarRootViewController()
         
@@ -293,5 +347,17 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(controllers, (tabbarController.selectedViewController as? UINavigationController)?.viewControllers.suffix(2))
         XCTAssertEqual(tabbarController.selectedIndex, 0)
         XCTAssertEqual((tabbarController.selectedViewController as? UINavigationController)?.viewControllers.count, 3)
+    }
+    
+    func testItCanFailDeeplinking() {
+        let deeplink = "test://frank/sinatra"
+        let controllers = router.route(
+            toDeeplink: deeplink,
+            behaviour: DeeplinkBehaviour(presentationStyle: .pushIfPossible,
+                                         updatableSearchPreference: .justInCurrentContext,
+                                         shouldFollowRemainder: false),
+            userInfo: nil
+        )
+        XCTAssert(controllers.isEmpty)
     }
 }

--- a/MERLin/MERLinTests/Tests/Router/RouterTests.swift
+++ b/MERLin/MERLinTests/Tests/Router/RouterTests.swift
@@ -49,7 +49,7 @@ class RouterTests: XCTestCase {
     func testRoutToPushWithoutCloseButton() {
         let step = PresentableRoutingStep(
             withStep: .mock(),
-            presentationMode: .push(withCloseButton: false, onClose: nil),
+            presentationMode: .push(withCloseButton: .none),
             animated: false
         )
         let expected = router.route(to: step)
@@ -61,7 +61,7 @@ class RouterTests: XCTestCase {
     func testRoutToPushWithCloseButton() {
         let step = PresentableRoutingStep(
             withStep: .mock(),
-            presentationMode: .push(withCloseButton: true, onClose: nil),
+            presentationMode: .push(withCloseButton: .title("Close", onClose: nil)),
             animated: false
         )
         let expected = router.route(to: step)
@@ -76,7 +76,7 @@ class RouterTests: XCTestCase {
         
         let step = PresentableRoutingStep(
             withStep: .mock(),
-            presentationMode: .push(withCloseButton: false, onClose: nil),
+            presentationMode: .push(withCloseButton: .none),
             animated: false
         )
         let expected = router.route(to: step)
@@ -99,8 +99,7 @@ class RouterTests: XCTestCase {
         let step = PresentableRoutingStep(
             withStep: .mock(),
             presentationMode: .modalWithNavigation(modalPresentationStyle: .fullScreen,
-                                                   withCloseButton: false,
-                                                   onClose: nil),
+                                                   withCloseButton: .none),
             animated: false
         )
         let expected = router.route(to: step)
@@ -114,8 +113,7 @@ class RouterTests: XCTestCase {
         let step = PresentableRoutingStep(
             withStep: .mock(),
             presentationMode: .modalWithNavigation(modalPresentationStyle: .fullScreen,
-                                                   withCloseButton: true,
-                                                   onClose: nil),
+                                                   withCloseButton: .title("Close", onClose: nil)),
             animated: false
         )
         let expected = router.route(to: step)

--- a/MERLin/MERLinTests/Tests/Router/RoutingStepPresentationModeTests.swift
+++ b/MERLin/MERLinTests/Tests/Router/RoutingStepPresentationModeTests.swift
@@ -13,27 +13,35 @@ import XCTest
 class RoutingStepPresentationModeTests: XCTestCase {
     func testItCanOverridePushWithCloseButton() {
         var value = 1
-        let mode = RoutingStepPresentationMode.push(withCloseButton: false, onClose: nil)
-        guard let newMode = mode.override(withCloseButton: true, onClose: { value += 1 }),
-            case let .push(closeButton, onClose) = newMode else {
+        let mode = RoutingStepPresentationMode.push(withCloseButton: .none)
+        guard let newMode = mode.override(withCloseButton: .title("Close", onClose: { value += 1 })),
+            case let .push(closeButton) = newMode else {
             XCTFail("newMode is not push")
             return
         }
-        XCTAssert(closeButton)
+        guard case let .title(_, onClose) = closeButton else {
+            XCTFail("button is not title")
+            return
+        }
+        
         onClose?()
         XCTAssert(value == 2)
     }
     
     func testItCanOverrideModalWithNavigation() {
         var value = 1
-        let mode = RoutingStepPresentationMode.modalWithNavigation(modalPresentationStyle: .currentContext, withCloseButton: false, onClose: nil)
-        guard let newMode = mode.override(withCloseButton: true, onClose: { value += 1 }),
-            case let .modalWithNavigation(style, closeButton, onClose) = newMode else {
+        let mode = RoutingStepPresentationMode.modalWithNavigation(modalPresentationStyle: .currentContext, withCloseButton: .none)
+        guard let newMode = mode.override(withCloseButton: .title("Close", onClose: { value += 1 })),
+            case let .modalWithNavigation(style, closeButton) = newMode else {
             XCTFail("newMode is not modal with navigation")
             return
         }
         XCTAssertEqual(style, .currentContext)
-        XCTAssert(closeButton)
+        
+        guard case let .title(_, onClose) = closeButton else {
+            XCTFail("button is not title")
+            return
+        }
         onClose?()
         XCTAssertEqual(value, 2)
     }
@@ -46,7 +54,7 @@ class RoutingStepPresentationModeTests: XCTestCase {
         ]
         
         for mode in modes {
-            XCTAssertNil(mode.override(withCloseButton: true) {})
+            XCTAssertNil(mode.override(withCloseButton: CloseButtonType.title("Close", onClose: nil)))
         }
     }
 }

--- a/MERLin/Podfile.lock
+++ b/MERLin/Podfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES:
   - SwiftFormat/CLI (~> 0.40.5)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - EnumKit
     - LNZWeakCollection
     - RxCocoa
@@ -43,4 +43,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 743e7c5bf9c8ee2178993004e987a2d8c02bcd45
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4


### PR DESCRIPTION
This PR enables a finer control over the close button for modals.

Now close buttons with images are possible.
The router has a "default" variable. Use that var to avoid repetition in your code. The default behaviour of that default var is a close button with title and nil onClose.

Override it to enable your preferred behaviour.