### PR TITLE
Removed compactMap for single and drivers in favour of the RxSwift implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 os: osx
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11
 podfile: ./MERLin/Podfile
 xcode_workspace: ./MERLin/MERLin.xcworkspace
 xcode_scheme: MERLin
-xcode_destination: platform=iOS Simulator,OS=11.4,name=iPhone X
+xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
 
 before_install:
     - pod repo update

--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.platform = :ios
-    s.version = "3.0.0"
+    s.version = "3.0.1"
     s.ios.deployment_target = '10.0'
     s.name = "MERLin"
  	s.summary      = "A framework to build an event based, reactive architecture for swift iOS projects"
@@ -23,7 +23,9 @@ Pod::Spec.new do |s|
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.3.2'
-    s.dependency 'RxEnumKit', '~>1.0.1'
+    s.dependency 'RxEnumKit', '~>1.0.2'
+    s.dependency 'RxSwift', '~>5.1.0'
+    s.dependency 'RxCocoa', '~>5.0.1'
 
     s.framework = "UIKit"
 	

--- a/MERLin.podspec
+++ b/MERLin.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
     }
     
 	s.dependency 'LNZWeakCollection', '~>1.3.2'
+    s.dependency 'EnumKit', '~>1.1.2'
     s.dependency 'RxEnumKit', '~>1.0.2'
     s.dependency 'RxSwift', '~>5.1.0'
     s.dependency 'RxCocoa', '~>5.0.1'

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -655,7 +655,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -828,7 +828,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -860,7 +860,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.merlintech.MERLin;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/MERLin/MERLin.xcodeproj/project.pbxproj
+++ b/MERLin/MERLin.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4B27C1729306A9F003F8132A /* Pods_MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB10A2EEC338E0B99AB8C5C0 /* Pods_MERLin.framework */; };
 		500652E621D3C14C009466F9 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500652E521D3C14C009466F9 /* RouterTests.swift */; };
 		500652E821D3C1A0009466F9 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500652E721D3C1A0009466F9 /* MockRouter.swift */; };
 		5006670721A983ED00CDA08C /* EventsProducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5006670621A983ED00CDA08C /* EventsProducerTests.swift */; };
@@ -53,7 +52,8 @@
 		50B1186F213BF84F008928AF /* RxSwift+EventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1186E213BF84F008928AF /* RxSwift+EventProtocol.swift */; };
 		50B11872213BF89E008928AF /* ModuleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11870213BF89E008928AF /* ModuleManagerTests.swift */; };
 		50B11873213BF89E008928AF /* DeeplinkableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B11871213BF89E008928AF /* DeeplinkableTests.swift */; };
-		834CC8B25EF895BF66E8C1EB /* Pods_MERLinTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 544ACCAB7B9C170AB13AAEEB /* Pods_MERLinTests.framework */; };
+		760BF87DDA5B32C3225116FB /* Pods_MERLinTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8DCDE153FE82002F124D51 /* Pods_MERLinTests.framework */; };
+		771B01263E07493EA6B6CA4E /* Pods_MERLin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 266F444C78F8FC09D110DF12 /* Pods_MERLin.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,9 +67,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0F42D72A6FA17F42CA96E673 /* Pods-MERLin.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.test.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.test.xcconfig"; sourceTree = "<group>"; };
-		2300FAB70E840CEEA053E4A3 /* Pods-MERLinTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.test.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.test.xcconfig"; sourceTree = "<group>"; };
-		479DED9B63CA69DAC8E89ACA /* Pods-MERLinTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.debug.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.debug.xcconfig"; sourceTree = "<group>"; };
+		266F444C78F8FC09D110DF12 /* Pods_MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		33623749A7B5F70F970FEDAC /* Pods-MERLin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.debug.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.debug.xcconfig"; sourceTree = "<group>"; };
 		500652E521D3C14C009466F9 /* RouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
 		500652E721D3C1A0009466F9 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
 		5006670621A983ED00CDA08C /* EventsProducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsProducerTests.swift; sourceTree = "<group>"; };
@@ -119,11 +118,12 @@
 		50B11870213BF89E008928AF /* ModuleManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleManagerTests.swift; sourceTree = "<group>"; };
 		50B11871213BF89E008928AF /* DeeplinkableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeeplinkableTests.swift; sourceTree = "<group>"; };
 		50FDFF8B214E737C00BC5CFD /* MERLin.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = MERLin.podspec; path = ../../MERLin.podspec; sourceTree = "<group>"; };
-		544ACCAB7B9C170AB13AAEEB /* Pods_MERLinTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLinTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		88A09449CF06B66FF9DE54FD /* Pods-MERLinTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.release.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.release.xcconfig"; sourceTree = "<group>"; };
-		88E5D6AF85982C4CA4848DBA /* Pods-MERLin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.release.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.release.xcconfig"; sourceTree = "<group>"; };
-		CB10A2EEC338E0B99AB8C5C0 /* Pods_MERLin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F80DABDF6C06FB8220758388 /* Pods-MERLin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.debug.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.debug.xcconfig"; sourceTree = "<group>"; };
+		670C8A8E553B14804805002B /* Pods-MERLin.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.test.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.test.xcconfig"; sourceTree = "<group>"; };
+		7D6ACB303A58E19D09D02C30 /* Pods-MERLinTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.debug.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.debug.xcconfig"; sourceTree = "<group>"; };
+		991493BFED89BD6235B81FD6 /* Pods-MERLinTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.release.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.release.xcconfig"; sourceTree = "<group>"; };
+		9F8DCDE153FE82002F124D51 /* Pods_MERLinTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MERLinTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A819543A237C1730EC038842 /* Pods-MERLinTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLinTests.test.xcconfig"; path = "Target Support Files/Pods-MERLinTests/Pods-MERLinTests.test.xcconfig"; sourceTree = "<group>"; };
+		B97B39313CA69E7A56F2AB61 /* Pods-MERLin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MERLin.release.xcconfig"; path = "Target Support Files/Pods-MERLin/Pods-MERLin.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,7 +131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B27C1729306A9F003F8132A /* Pods_MERLin.framework in Frameworks */,
+				771B01263E07493EA6B6CA4E /* Pods_MERLin.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,7 +140,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				501D6F0F2130BB4F00114F5A /* MERLin.framework in Frameworks */,
-				834CC8B25EF895BF66E8C1EB /* Pods_MERLinTests.framework in Frameworks */,
+				760BF87DDA5B32C3225116FB /* Pods_MERLinTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,7 +154,7 @@
 				501D6F122130BB4F00114F5A /* MERLinTests */,
 				501D6F062130BB4F00114F5A /* Products */,
 				BA66787E107E2D70E1410650 /* Pods */,
-				E0CFFA7B90CED79A029C96FE /* Frameworks */,
+				F76E700A6022C26CFBE9EFC1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -311,21 +311,21 @@
 		BA66787E107E2D70E1410650 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				F80DABDF6C06FB8220758388 /* Pods-MERLin.debug.xcconfig */,
-				0F42D72A6FA17F42CA96E673 /* Pods-MERLin.test.xcconfig */,
-				88E5D6AF85982C4CA4848DBA /* Pods-MERLin.release.xcconfig */,
-				479DED9B63CA69DAC8E89ACA /* Pods-MERLinTests.debug.xcconfig */,
-				2300FAB70E840CEEA053E4A3 /* Pods-MERLinTests.test.xcconfig */,
-				88A09449CF06B66FF9DE54FD /* Pods-MERLinTests.release.xcconfig */,
+				33623749A7B5F70F970FEDAC /* Pods-MERLin.debug.xcconfig */,
+				670C8A8E553B14804805002B /* Pods-MERLin.test.xcconfig */,
+				B97B39313CA69E7A56F2AB61 /* Pods-MERLin.release.xcconfig */,
+				7D6ACB303A58E19D09D02C30 /* Pods-MERLinTests.debug.xcconfig */,
+				A819543A237C1730EC038842 /* Pods-MERLinTests.test.xcconfig */,
+				991493BFED89BD6235B81FD6 /* Pods-MERLinTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		E0CFFA7B90CED79A029C96FE /* Frameworks */ = {
+		F76E700A6022C26CFBE9EFC1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CB10A2EEC338E0B99AB8C5C0 /* Pods_MERLin.framework */,
-				544ACCAB7B9C170AB13AAEEB /* Pods_MERLinTests.framework */,
+				266F444C78F8FC09D110DF12 /* Pods_MERLin.framework */,
+				9F8DCDE153FE82002F124D51 /* Pods_MERLinTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -349,7 +349,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 501D6F192130BB4F00114F5A /* Build configuration list for PBXNativeTarget "MERLin" */;
 			buildPhases = (
-				567E44AC601DCF2539A76A64 /* [CP] Check Pods Manifest.lock */,
+				7DE12B4F491F7FE99A1400C9 /* [CP] Check Pods Manifest.lock */,
 				501D6F002130BB4F00114F5A /* Sources */,
 				501D6F012130BB4F00114F5A /* Frameworks */,
 				501D6F022130BB4F00114F5A /* Headers */,
@@ -368,11 +368,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 501D6F1C2130BB4F00114F5A /* Build configuration list for PBXNativeTarget "MERLinTests" */;
 			buildPhases = (
-				E2933BEFC0EAF5E105C2BC43 /* [CP] Check Pods Manifest.lock */,
+				72DEC49C606334A95DD13246 /* [CP] Check Pods Manifest.lock */,
 				501D6F0A2130BB4F00114F5A /* Sources */,
 				501D6F0B2130BB4F00114F5A /* Frameworks */,
 				501D6F0C2130BB4F00114F5A /* Resources */,
-				3D89F8726E30312D8439BEA2 /* [CP] Embed Pods Frameworks */,
+				F1FE9BB8C5D9119873892248 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -441,24 +441,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3D89F8726E30312D8439BEA2 /* [CP] Embed Pods Frameworks */ = {
+		72DEC49C606334A95DD13246 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MERLinTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		567E44AC601DCF2539A76A64 /* [CP] Check Pods Manifest.lock */ = {
+		7DE12B4F491F7FE99A1400C9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -480,26 +485,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E2933BEFC0EAF5E105C2BC43 /* [CP] Check Pods Manifest.lock */ = {
+		F1FE9BB8C5D9119873892248 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-MERLinTests-checkManifestLockResult.txt",
+				"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MERLinTests/Pods-MERLinTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -637,7 +637,7 @@
 		};
 		50098A222219DC0E00CCC65A /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0F42D72A6FA17F42CA96E673 /* Pods-MERLin.test.xcconfig */;
+			baseConfigurationReference = 670C8A8E553B14804805002B /* Pods-MERLin.test.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -670,7 +670,7 @@
 		};
 		50098A232219DC0E00CCC65A /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2300FAB70E840CEEA053E4A3 /* Pods-MERLinTests.test.xcconfig */;
+			baseConfigurationReference = A819543A237C1730EC038842 /* Pods-MERLinTests.test.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = ZJ8CN8P2Z5;
@@ -810,7 +810,7 @@
 		};
 		501D6F1A2130BB4F00114F5A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F80DABDF6C06FB8220758388 /* Pods-MERLin.debug.xcconfig */;
+			baseConfigurationReference = 33623749A7B5F70F970FEDAC /* Pods-MERLin.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -842,7 +842,7 @@
 		};
 		501D6F1B2130BB4F00114F5A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88E5D6AF85982C4CA4848DBA /* Pods-MERLin.release.xcconfig */;
+			baseConfigurationReference = B97B39313CA69E7A56F2AB61 /* Pods-MERLin.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -873,7 +873,7 @@
 		};
 		501D6F1D2130BB4F00114F5A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 479DED9B63CA69DAC8E89ACA /* Pods-MERLinTests.debug.xcconfig */;
+			baseConfigurationReference = 7D6ACB303A58E19D09D02C30 /* Pods-MERLinTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = ZJ8CN8P2Z5;
@@ -893,7 +893,7 @@
 		};
 		501D6F1E2130BB4F00114F5A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88A09449CF06B66FF9DE54FD /* Pods-MERLinTests.release.xcconfig */;
+			baseConfigurationReference = 991493BFED89BD6235B81FD6 /* Pods-MERLinTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = ZJ8CN8P2Z5;

--- a/MERLin/MERLin/Extensions/RxExtension.swift
+++ b/MERLin/MERLin/Extensions/RxExtension.swift
@@ -39,18 +39,6 @@ public extension ObservableType {
     }
 }
 
-public extension PrimitiveSequenceType where Trait == MaybeTrait {
-    func compactMap<R>(_ transform: @escaping (Element) throws -> R?) -> Maybe<R> {
-        return map(transform).filter { $0 != nil }.map { $0! }
-    }
-}
-
-public extension SharedSequenceConvertibleType {
-    func compactMap<R>(_ transform: @escaping (Element) -> R?) -> SharedSequence<SharingStrategy, R> {
-        return map(transform).filter { $0 != nil }.map { $0! }
-    }
-}
-
 public extension PrimitiveSequence where Trait == SingleTrait {
     func unwrapOrError<T>(_ error: Error) -> Single<T> where Element == T? {
         return filter { $0 != nil }.map { $0! }

--- a/MERLin/MERLin/Extensions/RxSwift+EventProtocol.swift
+++ b/MERLin/MERLin/Extensions/RxSwift+EventProtocol.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 Giuseppe Lanza. All rights reserved.
 //
 
-import RxCocoa
 import RxSwift
 
 public extension ObservableType where Element: EventProtocol {

--- a/MERLin/MERLin/Routing/RouterProtocol.swift
+++ b/MERLin/MERLin/Routing/RouterProtocol.swift
@@ -86,10 +86,10 @@ public extension Router {
     }
     
     @discardableResult func route(to viewController: UIViewController, withPresentationMode mode: RoutingStepPresentationMode, animated: Bool) -> UIViewController? {
-        if case let .embed(info) = mode {
+        if case let .embed(parentController, view) = mode {
             // We can avoid to compute the topController in this case
-            os_log("Embedding %@ in %@", log: .router, type: .debug, viewController, info.parentController)
-            return embed(viewController: viewController, embedInfo: info)
+            os_log("Embedding %@ in %@", log: .router, type: .debug, viewController, parentController)
+            return embed(viewController: viewController, embedInfo: (parentController, view))
         }
         
         var topController = currentViewController()

--- a/MERLin/MERLinTests/Tests/RxExtensions/RxExtensionTests.swift
+++ b/MERLin/MERLinTests/Tests/RxExtensions/RxExtensionTests.swift
@@ -171,26 +171,6 @@ class RxExtensionTests: XCTestCase, RxExtensionTestCase {
         XCTAssertEqual(observer.events, expected)
     }
     
-    func testItCanCompactMapDriver() {
-        let events = [
-            Recorded.next(1, "1"),
-            .next(2, "2"),
-            .next(3, "a")
-        ]
-        
-        let observer = buildTest(emitting: events) { emitter in
-            emitter.asDriverIgnoreError()
-                .compactMap(Int.init)
-        }
-        
-        let expected = [
-            Recorded.next(1, 1),
-            .next(2, 2)
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
-    }
-    
     // MARK: Single Extension
     
     func testItCanUnwrapSingle() {
@@ -314,22 +294,6 @@ class RxExtensionTests: XCTestCase, RxExtensionTestCase {
         
         let expected: [Recorded<Event<Bool>>] = [
             .error(200, expectedError)
-        ]
-        
-        XCTAssertEqual(observer.events, expected)
-    }
-    
-    // MARK: Maybe Extension
-    
-    func testItCanCompactMapMaybe() {
-        let observer = buildTest(value: "1") { emitter in
-            emitter.asMaybe()
-                .compactMap(Int.init)
-        }
-        
-        let expected = [
-            Recorded.next(200, 1),
-            .completed(200)
         ]
         
         XCTAssertEqual(observer.events, expected)

--- a/MERLin/Podfile
+++ b/MERLin/Podfile
@@ -4,6 +4,7 @@ inhibit_all_warnings! # supresses pods project warnings
 
 def common
     pod 'LNZWeakCollection', '~>1.3.2'
+    pod 'EnumKit', '~>1.1.2'
     pod 'RxEnumKit', '~>1.0.1'
     pod 'SwiftFormat/CLI', '~>0.40.5'
 end

--- a/MERLin/Podfile.lock
+++ b/MERLin/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - EnumKit (1.1.1)
+  - EnumKit (1.1.2)
   - LNZWeakCollection (1.3.2)
   - RxCocoa (5.0.1):
     - RxRelay (~> 5)
@@ -15,6 +15,7 @@ PODS:
   - SwiftFormat/CLI (0.40.14)
 
 DEPENDENCIES:
+  - EnumKit (~> 1.1.2)
   - LNZWeakCollection (~> 1.3.2)
   - RxEnumKit (~> 1.0.1)
   - RxTest (~> 5.0.0)
@@ -32,7 +33,7 @@ SPEC REPOS:
     - SwiftFormat
 
 SPEC CHECKSUMS:
-  EnumKit: b49db845ff6de43d55b58214fb89e676edc349fa
+  EnumKit: d44634a9755c252cd0b52c8ec5e8e97160895c6b
   LNZWeakCollection: 0211da4f8778cb35d1b9fa788a3cb395e26a0226
   RxCocoa: e741b9749968e8a143e2b787f1dfbff2b63d0a5c
   RxEnumKit: 76495d3640bbd2a4c672150f1c1da419cf99d342
@@ -41,6 +42,6 @@ SPEC CHECKSUMS:
   RxTest: 0132f952a61da82d5233abedaa559df91e5330e5
   SwiftFormat: 21c9c3c748d5fcece493d8610eee23df15393458
 
-PODFILE CHECKSUM: 743e7c5bf9c8ee2178993004e987a2d8c02bcd45
+PODFILE CHECKSUM: 25934ce422ffd440022efe94b3a682a3800533bd
 
 COCOAPODS: 1.9.0

--- a/MERLin/Podfile.lock
+++ b/MERLin/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - EnumKit (1.0.0)
+  - EnumKit (1.1.1)
   - LNZWeakCollection (1.3.2)
-  - RxCocoa (5.0.0):
+  - RxCocoa (5.0.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
-  - RxEnumKit (1.0.1):
-    - EnumKit (~> 1.0.0)
+  - RxEnumKit (1.0.2):
+    - EnumKit (~> 1.1.1)
     - RxCocoa (~> 5.0.0)
-  - RxRelay (5.0.0):
+  - RxRelay (5.1.1):
     - RxSwift (~> 5)
-  - RxSwift (5.0.0)
-  - RxTest (5.0.0):
+  - RxSwift (5.1.1)
+  - RxTest (5.0.1):
     - RxSwift (~> 5)
-  - SwiftFormat/CLI (0.40.9)
+  - SwiftFormat/CLI (0.40.14)
 
 DEPENDENCIES:
   - LNZWeakCollection (~> 1.3.2)
@@ -32,15 +32,15 @@ SPEC REPOS:
     - SwiftFormat
 
 SPEC CHECKSUMS:
-  EnumKit: 8ee9561b3a7d2696d2e5aa37d5b9eba5f7139783
+  EnumKit: b49db845ff6de43d55b58214fb89e676edc349fa
   LNZWeakCollection: 0211da4f8778cb35d1b9fa788a3cb395e26a0226
-  RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
-  RxEnumKit: f51b6ae14fdae994a66b8a39d166116b8e0befc1
-  RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
-  RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
-  RxTest: 4349afe98f564e0a9bc19063368904622d17d49a
-  SwiftFormat: 6b67b6e7fe73d664f0cbb4f13721f130462c86a5
+  RxCocoa: e741b9749968e8a143e2b787f1dfbff2b63d0a5c
+  RxEnumKit: 76495d3640bbd2a4c672150f1c1da419cf99d342
+  RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
+  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
+  RxTest: 0132f952a61da82d5233abedaa559df91e5330e5
+  SwiftFormat: 21c9c3c748d5fcece493d8610eee23df15393458
 
 PODFILE CHECKSUM: 743e7c5bf9c8ee2178993004e987a2d8c02bcd45
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.0

--- a/MERLinSample/Podfile.lock
+++ b/MERLinSample/Podfile.lock
@@ -1,24 +1,25 @@
 PODS:
-  - EnumKit (1.0.0)
+  - EnumKit (1.1.1)
   - LNZWeakCollection (1.3.2)
   - MERLin (3.0.0):
     - LNZWeakCollection (~> 1.3.2)
-    - RxEnumKit (~> 1.0.1)
-  - RxCocoa (5.0.0):
+    - RxEnumKit (~> 1.0.2)
+    - RxSwift (~> 5.1.0)
+  - RxCocoa (5.0.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
-  - RxEnumKit (1.0.1):
-    - EnumKit (~> 1.0.0)
+  - RxEnumKit (1.0.2):
+    - EnumKit (~> 1.1.1)
     - RxCocoa (~> 5.0.0)
-  - RxRelay (5.0.0):
+  - RxRelay (5.1.1):
     - RxSwift (~> 5)
-  - RxSwift (5.0.0)
+  - RxSwift (5.1.1)
 
 DEPENDENCIES:
   - MERLin (from `../`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - EnumKit
     - LNZWeakCollection
     - RxCocoa
@@ -31,14 +32,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  EnumKit: 8ee9561b3a7d2696d2e5aa37d5b9eba5f7139783
+  EnumKit: b49db845ff6de43d55b58214fb89e676edc349fa
   LNZWeakCollection: 0211da4f8778cb35d1b9fa788a3cb395e26a0226
-  MERLin: fcc7a1671122be4e25136f3fd644aea180e32b70
-  RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
-  RxEnumKit: f51b6ae14fdae994a66b8a39d166116b8e0befc1
-  RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
-  RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
+  MERLin: 8abf492167e2df6b301ad185fcdda08bd8042f51
+  RxCocoa: e741b9749968e8a143e2b787f1dfbff2b63d0a5c
+  RxEnumKit: 76495d3640bbd2a4c672150f1c1da419cf99d342
+  RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
+  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
 
 PODFILE CHECKSUM: a6ee1cdd068da55588ef8cb0033cd9d15dfe14e3
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.0


### PR DESCRIPTION
This will be version 3.0.1.

This change should not be source breaking on an healthy project in which RxSwift is up to date. Your code will use RxSwift implementation instead of MERLin implementation for `compactMap` on Singles and Drivers (it was already using RxSwift version for ObservableTypes).